### PR TITLE
Status and log endpoints

### DIFF
--- a/odyn/Cargo.lock
+++ b/odyn/Cargo.lock
@@ -72,16 +72,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bumpalo"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+dependencies = [
+ "byteorder",
+ "iovec",
+]
 
 [[package]]
 name = "bytes"
@@ -306,6 +328,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
+
+[[package]]
 name = "libc"
 version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,7 +447,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
 dependencies = [
- "bytes",
+ "bytes 1.2.1",
  "futures",
  "log",
  "netlink-packet-core",
@@ -416,7 +462,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92b654097027250401127914afb37cb1f311df6610a9891ff07a757e94199027"
 dependencies = [
- "bytes",
+ "bytes 1.2.1",
  "futures",
  "libc",
  "log",
@@ -428,6 +474,19 @@ name = "nix"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5e06129fb611568ef4e868c14b326274959aa70ff7776e9d55323531c374945"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",
@@ -467,14 +526,19 @@ dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "circbuf",
  "clap",
+ "futures",
+ "json",
  "log",
  "nix 0.24.2",
  "pretty_env_logger",
  "rand",
  "rtnetlink",
- "signal-hook",
+ "rustls",
+ "rustls-pemfile",
  "tokio",
  "tokio-pipe",
+ "tokio-rustls",
+ "tokio-vsock",
 ]
 
 [[package]]
@@ -651,6 +715,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rtnetlink"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,10 +754,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.20.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "semver"
@@ -726,16 +836,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +868,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
@@ -828,7 +934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
 dependencies = [
  "autocfg",
- "bytes",
+ "bytes 1.2.1",
  "libc",
  "memchr",
  "mio",
@@ -864,10 +970,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-vsock"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d2ad075b54bbb450ae2e3770211d7954362a488fcd386085c9fbb6d787ade8b"
+dependencies = [
+ "bytes 0.4.12",
+ "futures",
+ "libc",
+ "tokio",
+ "vsock",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "version_check"
@@ -876,10 +1012,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "vsock"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32675ee2b3ce5df274c0ab52d19b28789632406277ca26bffee79a8e27dc133"
+dependencies = [
+ "libc",
+ "nix 0.23.1",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "web-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "winapi"

--- a/odyn/Cargo.toml
+++ b/odyn/Cargo.toml
@@ -9,6 +9,10 @@ edition = "2021"
 anyhow = { version = "1.0", features = ["std"] }
 tokio = { version = "1.20", features = ["full"] }
 tokio-pipe = "0.2"
+tokio-vsock = "0.3"
+tokio-rustls = "0.23"
+rustls = "0.20"
+rustls-pemfile = "1.0"
 clap = { version = "3.1", features = ["derive"] }
 aws-nitro-enclaves-nsm-api = "0.2.1"
 log = "0.4"
@@ -16,7 +20,8 @@ pretty_env_logger = "0.4"
 rtnetlink = "0.11"
 circbuf = "0.2"
 nix = "0.24"
-signal-hook = "0.3"
+futures = "0.3"
 
 assert2 = "0.3"
 rand = { version = "0.8", features = ["std", "std_rng"] }
+json = "0.12"

--- a/odyn/src/launcher.rs
+++ b/odyn/src/launcher.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 use std::os::unix::process::CommandExt;
 use anyhow::{anyhow, Result};
 use log::debug;
+use tokio::task::JoinHandle;
 
 pub struct Credentials {
     pub uid: u32,
@@ -17,12 +18,21 @@ pub enum ExitStatus {
     Signaled(Signal),
 }
 
+impl std::fmt::Display for ExitStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self {
+            ExitStatus::Exited(code) => write!(f, "exited with {}", code),
+            ExitStatus::Signaled(sig) => write!(f, "terminated by {}", sig),
+        }
+    }
+}
+
 // runs the child and reaps all of its children as well
 pub fn run_child(argv: &[OsString], creds: &Credentials) -> Result<ExitStatus> {
     // Don't use tokio::process::Command because it wants to reap the process.
     // However we need to run waitpid() ourselves to reap the zombies and it'll
     // end up picking up the spawned child as well.
-    let mut child = Command::new(&argv[0])
+    let child = Command::new(&argv[0])
         .args(&argv[1..])
         .uid(creds.uid)
         .gid(creds.gid)
@@ -33,6 +43,13 @@ pub fn run_child(argv: &[OsString], creds: &Credentials) -> Result<ExitStatus> {
     let child_pid = Pid::from_raw(child.id() as i32);
 
     reap(child_pid)
+}
+
+// runs the child and reaps all of its children as well
+pub fn start_child(argv: Vec<OsString>, creds: Credentials) -> JoinHandle<Result<ExitStatus>> {
+    tokio::task::spawn_blocking(move || {
+        run_child(&argv, &creds)
+    })
 }
 
 // Reap processes until a process with sentinel pid exits.

--- a/odyn/src/main.rs
+++ b/odyn/src/main.rs
@@ -1,12 +1,19 @@
-use log::{info, error};
-use std::ffi::OsString;
-use clap::{Parser};
-use anyhow::Result;
-
 pub mod enclave;
 pub mod nsm;
 pub mod console;
 pub mod launcher;
+pub mod vsock;
+pub mod tls;
+
+use log::{info, error};
+use std::ffi::OsString;
+use clap::{Parser};
+use anyhow::{Result};
+use console::{AppLog, AppStatus};
+
+// start "internal" ports above the 16-bit boundary (reserved for proxying TCP)
+const STATUS_PORT: u32 = 17000;
+const APP_LOG_PORT: u32 = 17001;
 
 #[derive(Parser)]
 struct CliArgs {
@@ -20,35 +27,38 @@ struct CliArgs {
     entrypoint: Vec<OsString>,
 }
 
+
 async fn run(args: &CliArgs) -> Result<()> {
+    let mut console_task = None;
+    if !args.no_console {
+        let app_log = AppLog::with_stdio_redirect()?;
+        console_task = Some(app_log.start_serving(APP_LOG_PORT));
+    }
+
+    let app_status = AppStatus::new();
+    let app_status_task = app_status.start_serving(STATUS_PORT);
+
     if !args.no_bootstrap {
         enclave::bootstrap().await?;
         info!("Enclave initialized");
     }
 
-    let mut console_task = None;
-    if !args.no_console {
-        let (log_w, mut log_s, _log_r) = console::new_app_log()?;
-        log_w.redirect_stdio()?;
-
-        console_task = Some(tokio::spawn(async move {
-            log_s.run().await
-        }));
-    }
-
-    info!("Starting {:?}", args.entrypoint);
-    let entrypoint = args.entrypoint.clone();
     let creds = launcher::Credentials{
         uid: 100,
         gid: 100,
     };
-    tokio::task::spawn_blocking(move || {
-        launcher::run_child(&entrypoint, &creds)
-    }).await??;
+
+    info!("Starting {:?}", args.entrypoint);
+    let exit_status = launcher::start_child(args.entrypoint.clone(), creds).await??;
+    info!("Entrypoint {}", exit_status);
+
+    app_status.exited(exit_status);
+
+    app_status_task.await??;
 
     if let Some(task) = console_task {
         task.abort();
-        task.await??;
+        _ = task.await;
     }
 
     Ok(())

--- a/odyn/src/tls.rs
+++ b/odyn/src/tls.rs
@@ -1,0 +1,39 @@
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
+use std::sync::Arc;
+use rustls::{ServerConfig, Certificate, PrivateKey};
+use anyhow::{Result, anyhow};
+use log::info;
+
+fn load_certs(path: &Path) -> Result<Vec<Certificate>> {
+    rustls_pemfile::certs(&mut BufReader::new(File::open(path)?))
+        .map_err(|_| anyhow!("invalid cert"))
+        .map(|mut certs| certs.drain(..).map(Certificate).collect())
+}
+
+fn load_keys(path: &Path) -> Result<Vec<PrivateKey>> {
+    let mut key_bufs =
+        rustls_pemfile::pkcs8_private_keys(&mut BufReader::new(File::open(path)?))
+            .map_err(|_| anyhow!("invalid key"))?;
+
+    let keys: Vec<PrivateKey> = key_bufs
+        .drain(..)
+        .map(|buf| PrivateKey(buf))
+        .collect();
+
+    info!("Loaded {} TLS keys", keys.len());
+
+    Ok(keys)
+}
+
+pub fn load_tls_config(key: &Path, cert: &Path) -> Result<Arc<ServerConfig>> {
+    let certs = load_certs(cert)?;
+    let mut keys = load_keys(key)?;
+
+    Ok(Arc::new(rustls::ServerConfig::builder()
+        .with_safe_defaults()
+        .with_no_client_auth()
+        .with_single_cert(certs, keys.remove(0))?))
+}
+

--- a/odyn/src/vsock/ingress.rs
+++ b/odyn/src/vsock/ingress.rs
@@ -1,0 +1,71 @@
+use std::sync::Arc;
+use log::{info, error};
+use anyhow::{Result};
+use rustls::ServerConfig;
+use tokio_vsock::{VsockListener, VsockStream};
+use tokio_rustls::TlsAcceptor;
+use tokio_rustls::server::TlsStream;
+use futures::{Stream, StreamExt};
+
+pub type TlsVsock = TlsStream<VsockStream>;
+
+// Listen on a vsock with the given port.
+// Returns a Stream of connected sockets.
+pub fn serve(port: u32) -> Result<impl Stream<Item=VsockStream>> {
+    let listener = VsockListener::bind(super::VMADDR_CID_ANY, port)?;
+
+    info!("Listening on vsock port {}", port);
+    let stream = listener.incoming()
+        .filter_map(move |result| {
+            async move {
+                match result {
+                    Ok(vsock) => {
+                        info!("Connection accepted");
+                        Some(vsock)
+                    },
+
+                    Err(e) => {
+                        error!("Failed to accept a vsock: {}", e);
+                        None
+                    }
+                }
+            }
+        });
+
+    Ok(stream)
+}
+
+
+// Listen on a vsock with the given port for TLS connections.
+// Returns a Stream of TLS connected sockets.
+pub fn tls_serve(port: u32, tls_config: Arc<ServerConfig>) -> Result<impl Stream<Item=TlsVsock>> {
+    let acceptor = TlsAcceptor::from(tls_config);
+    let listener = VsockListener::bind(super::VMADDR_CID_ANY, port)?;
+
+    info!("Listening on TLS vsock port {}", port);
+    let stream = listener.incoming()
+        .filter_map(move |result| {
+            let acceptor = acceptor.clone();
+            async move {
+                match result {
+                    Ok(vsock) => {
+                        info!("Connection accepted");
+                        match acceptor.accept(vsock).await {
+                            Ok(vsock) => Some(vsock),
+                            Err(e) => {
+                                error!("TLS handshake failed: {}", e);
+                                None
+                            }
+                        }
+                    },
+
+                    Err(e) => {
+                        error!("Failed to accept a vsock: {}", e);
+                        None
+                    }
+                }
+            }
+        });
+
+    Ok(stream)
+}

--- a/odyn/src/vsock/mod.rs
+++ b/odyn/src/vsock/mod.rs
@@ -1,0 +1,5 @@
+pub const VMADDR_CID_ANY: u32 = 0xFFFFFFFF;
+pub const VMADDR_CID_LOCAL: u32 = 1;
+pub const VMADDR_CID_HOST: u32 = 2;
+
+pub mod ingress;


### PR DESCRIPTION
- Vsock port 17000 exposes the current enclave status in JSON form. The JSON object is newline terminated and streams status updates. For example: `{ "status": "running" }\n { "status": "exited", "code": 0 }\n`

- Vsock port 17001 exposes the enclave userspace log. This is the aggregate of odyn itself and the entrypoint (app) that it launches. Only about 128KB of log data is maintained.