### PR TITLE
Add a 'run-eif' sub-command to enclaver

### DIFF
--- a/enclaver/src/build.rs
+++ b/enclaver/src/build.rs
@@ -1,11 +1,11 @@
 use crate::images::{FileBuilder, FileSource, ImageManager, ImageRef, LayerBuilder};
+use crate::nitro_cli::EIFInfo;
 use crate::policy::{load_policy, Policy};
 use anyhow::{anyhow, Result};
 use bollard::container::{Config, LogOutput, LogsOptions, WaitContainerOptions};
 use bollard::models::{HostConfig, Mount, MountTypeEnum};
 use bollard::Docker;
 use futures_util::stream::{StreamExt, TryStreamExt};
-use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -27,24 +27,6 @@ const RELEASE_BASE_IMAGE: &str =
 pub struct EnclaveArtifactBuilder {
     docker: Arc<Docker>,
     image_manager: ImageManager,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct EIFInfo {
-    #[serde(rename = "Measurements")]
-    measurements: EIFMeasurements,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct EIFMeasurements {
-    #[serde(rename = "PCR0")]
-    pcr0: String,
-
-    #[serde(rename = "PCR1")]
-    pcr1: String,
-
-    #[serde(rename = "PCR2")]
-    pcr2: String,
 }
 
 impl EnclaveArtifactBuilder {

--- a/enclaver/src/images.rs
+++ b/enclaver/src/images.rs
@@ -36,6 +36,7 @@ pub struct ImageManager {
 
 impl ImageManager {
     /// Constructs a new ImageManager pointing to a local Docker daemon.
+    #[allow(dead_code)]
     pub fn new() -> Result<Self> {
         let docker_client = Arc::new(Docker::connect_with_local_defaults()?);
 
@@ -129,8 +130,15 @@ impl ImageManager {
 }
 
 pub enum FileSource {
-    Local { path: PathBuf },
-    Image { name: String, path: PathBuf },
+    Local {
+        path: PathBuf,
+    },
+
+    #[allow(dead_code)]
+    Image {
+        name: String,
+        path: PathBuf,
+    },
 }
 
 pub struct FileBuilder {

--- a/enclaver/src/lib.rs
+++ b/enclaver/src/lib.rs
@@ -1,5 +1,8 @@
 extern crate core;
 
 pub mod build;
+
 mod images;
+mod nitro_cli;
 mod policy;
+pub mod run;

--- a/enclaver/src/nitro_cli.rs
+++ b/enclaver/src/nitro_cli.rs
@@ -1,0 +1,190 @@
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::Stdio;
+use tokio::process::Command;
+
+pub struct NitroCLI {
+    program: String,
+}
+
+impl NitroCLI {
+    pub fn new() -> Self {
+        Self {
+            program: String::from("nitro-cli"),
+        }
+    }
+
+    pub async fn run_and_deserialize_output<T>(&self, args: impl NitroCLIArgs) -> Result<T>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let child = Command::new(&self.program)
+            .args(args.to_args()?)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|err| anyhow!("failed to execute nitro-cli: {}", err))?;
+
+        let output = child.wait_with_output().await?;
+
+        if output.status.success() {
+            Ok(serde_json::from_slice(&output.stdout)?)
+        } else {
+            Err(anyhow!(
+                "nitro-cli failed: {}",
+                String::from_utf8(output.stderr)?
+            ))
+        }
+    }
+
+    pub async fn run_enclave(&self, args: RunEnclaveArgs) -> Result<EnclaveInfo> {
+        Ok(self.run_and_deserialize_output(args).await?)
+    }
+
+    pub async fn run_enclave_with_debug(&self, args: RunEnclaveArgs) -> Result<()> {
+        let mut cmd_args = args.to_args()?;
+        cmd_args.push("--debug-mode".into());
+        cmd_args.push("--attach-console".into());
+
+        let exit_status = Command::new(&self.program)
+            .args(cmd_args)
+            .spawn()
+            .map_err(|err| anyhow!("failed to execute nitro-cli: {}", err))?
+            .wait()
+            .await?;
+
+        match exit_status.success() {
+            true => Ok(()),
+            false => Err(anyhow!("nitro-cli failed")),
+        }
+    }
+
+    pub async fn describe_enclaves(&self) -> Result<Vec<EnclaveInfo>> {
+        Ok(self
+            .run_and_deserialize_output(DescribeEnclavesArgs {})
+            .await?)
+    }
+
+    pub async fn terminate_enclave(&self, enclave_id: &str) -> Result<()> {
+        let res: EnclaveTerminationStatus = self
+            .run_and_deserialize_output(TerminateEnclaveArgs {
+                enclave_id: enclave_id.to_string(),
+            })
+            .await?;
+
+        match res.terminated {
+            true => Ok(()),
+            false => Err(anyhow!("nitro-cli failed to terminate enclave")),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct EIFInfo {
+    #[serde(rename = "Measurements")]
+    measurements: EIFMeasurements,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct EIFMeasurements {
+    #[serde(rename = "PCR0")]
+    pcr0: String,
+
+    #[serde(rename = "PCR1")]
+    pcr1: String,
+
+    #[serde(rename = "PCR2")]
+    pcr2: String,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct EnclaveInfo {
+    #[serde(rename = "EnclaveName")]
+    pub name: String,
+
+    #[serde(rename = "EnclaveID")]
+    pub id: String,
+
+    #[serde(rename = "ProcessID")]
+    pub process_id: i32,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct EnclaveTerminationStatus {
+    #[serde(rename = "EnclaveID")]
+    pub id: String,
+
+    #[serde(rename = "Terminated")]
+    pub terminated: bool,
+}
+
+pub trait NitroCLIArgs {
+    fn to_args(&self) -> Result<Vec<OsString>>;
+}
+
+pub struct RunEnclaveArgs {
+    pub cpu_count: i32,
+    pub memory_mb: i32,
+    pub eif_path: PathBuf,
+    pub cid: Option<i32>,
+}
+
+impl NitroCLIArgs for RunEnclaveArgs {
+    fn to_args(&self) -> Result<Vec<OsString>> {
+        let mut args = vec![OsString::from("run-enclave")];
+
+        if self.cpu_count < 1 {
+            return Err(anyhow!(
+                "at least 1 CPU is required, got: {}",
+                self.cpu_count
+            ));
+        } else {
+            args.push("--cpu-count".into());
+            args.push(format!("{}", self.cpu_count).into());
+        }
+
+        if self.memory_mb < 64 {
+            return Err(anyhow!(
+                "at least 64MiB of memory are required, got: {}",
+                self.memory_mb
+            ));
+        } else {
+            args.push("--memory".into());
+            args.push(format!("{}", self.memory_mb).into());
+        }
+
+        args.push("--eif-path".into());
+        args.push(self.eif_path.clone().into());
+
+        if let Some(cid) = self.cid {
+            args.push("--enclave-cid".into());
+            args.push(format!("{}", cid).into());
+        }
+
+        Ok(args)
+    }
+}
+
+pub struct DescribeEnclavesArgs {}
+
+impl NitroCLIArgs for DescribeEnclavesArgs {
+    fn to_args(&self) -> Result<Vec<OsString>> {
+        Ok(vec![OsString::from("describe-enclaves")])
+    }
+}
+
+pub struct TerminateEnclaveArgs {
+    pub enclave_id: String,
+}
+
+impl NitroCLIArgs for TerminateEnclaveArgs {
+    fn to_args(&self) -> Result<Vec<OsString>> {
+        Ok(vec![
+            OsString::from("terminate-enclave"),
+            OsString::from("--enclave-id"),
+            OsString::from(&self.enclave_id),
+        ])
+    }
+}

--- a/enclaver/src/run.rs
+++ b/enclaver/src/run.rs
@@ -1,0 +1,112 @@
+use crate::nitro_cli::{NitroCLI, RunEnclaveArgs};
+use anyhow::{anyhow, Result};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+pub struct Enclave {
+    cli: NitroCLI,
+    eif_path: PathBuf,
+    cpu_count: i32,
+    memory_mb: i32,
+    enclave_id: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum EnclaveState {
+    None,
+    Running(String),
+    Stopped(String),
+}
+
+impl Enclave {
+    pub fn new<P>(eif_path: P, cpu_count: i32, memory_mb: i32) -> Self
+    where
+        P: AsRef<Path>,
+    {
+        Self {
+            cli: NitroCLI::new(),
+            eif_path: eif_path.as_ref().to_path_buf(),
+            cpu_count,
+            memory_mb,
+            enclave_id: None,
+        }
+    }
+
+    pub async fn start(&mut self) -> Result<EnclaveState> {
+        if let Some(_) = self.enclave_id {
+            return Err(anyhow!("Enclave already started"));
+        }
+
+        let enclave_info = self
+            .cli
+            .run_enclave(RunEnclaveArgs {
+                cpu_count: self.cpu_count,
+                memory_mb: self.memory_mb,
+                eif_path: self.eif_path.clone(),
+                cid: None,
+            })
+            .await?;
+
+        println!("Enclave: {:#?}", enclave_info);
+
+        self.enclave_id = Some(enclave_info.id.clone());
+
+        Ok(EnclaveState::Running(enclave_info.id.clone()))
+    }
+
+    pub async fn run_with_debug(&self) -> Result<()> {
+        self.cli
+            .run_enclave_with_debug(RunEnclaveArgs {
+                cpu_count: self.cpu_count,
+                memory_mb: self.memory_mb,
+                eif_path: self.eif_path.clone(),
+                cid: None,
+            })
+            .await
+    }
+
+    pub async fn state(&self) -> Result<EnclaveState> {
+        match self.enclave_id {
+            Some(ref id) => {
+                let exists = self
+                    .cli
+                    .describe_enclaves()
+                    .await?
+                    .into_iter()
+                    .any(|e| e.id == *id);
+
+                match exists {
+                    true => Ok(EnclaveState::Running(id.clone())),
+                    false => Ok(EnclaveState::Stopped(id.clone())),
+                }
+            }
+            None => Ok(EnclaveState::None),
+        }
+    }
+
+    pub async fn stop(&self) -> Result<()> {
+        match self.enclave_id {
+            Some(ref id) => {
+                self.cli.terminate_enclave(id).await?;
+                Ok(())
+            }
+            None => Err(anyhow!("Enclave not started")),
+        }
+    }
+
+    pub async fn wait(&self) -> Result<()> {
+        loop {
+            match self.state().await? {
+                EnclaveState::Running(_) => {
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+                EnclaveState::Stopped(_) => {
+                    return Ok(());
+                }
+                EnclaveState::None => {
+                    return Err(anyhow!("Enclave not started"));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently this just wraps nitro-cli, but remains in the foreground until either the enclave terminates or one of SIGINT or SIGTERM is received, at which point it attempts to terminate the enclave.

This runs an EIF directly, as opposed to an OCI artifact, so I'm calling it `run-eif` instead of `run`. This command is intended as a direct replacement for the existing Go `enclaver-wrapper` command used in the self-executing containers. In the future we could additionally or instead add a `run` sub-command that uses most of the same code to execute an OCI artifact (or we could rename this if we decide not to do OCI at all).

Running with --debug-mode runs the enclave in debug mode, and pipes its console to stdout/stderr.

Example (this enclave crashes because it has my old Go proxy in it, and nothing on the host for it to talk to):

```
$ enclaver run-eif --eif-file ../app.eif --cpu-count 2 --memory-mb 512
Enclave: EnclaveInfo {
    name: "app",
    id: "i-0496411ab5adb3a89-enc1836bb5ff7abc34",
    process_id: 30136,
}
Enclave exited
```
