### PR TITLE
RFR: Multi-Architecture nitro-cli Containers

### DIFF
--- a/.github/workflows/build-nitro-cli.yaml
+++ b/.github/workflows/build-nitro-cli.yaml
@@ -12,18 +12,23 @@ jobs:
       id-token: 'write'
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - id: auth
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v0'
         with:
           workload_identity_provider: 'projects/77991489452/locations/global/workloadIdentityPools/gh-actions-identity-pool/providers/gh-actions-identity-provider'
           service_account: 'github-actions-service-account@edgebit-containers.iam.gserviceaccount.com'
-      - name: Build Nitro CLI Image
+      - name: Configure Docker Auth
         run: |
           gcloud auth configure-docker us-docker.pkg.dev
-          docker build \
-            -t us-docker.pkg.dev/edgebit-containers/containers/nitro-cli:latest \
-            -f builder/dockerfiles/nitro-cli.dockerfile \
-            .
-          docker image push us-docker.pkg.dev/edgebit-containers/containers/nitro-cli
+      - name: Build Nitro CLI Image
+        uses: docker/build-push-action@v3
+        with:
+          file: builder/dockerfiles/nitro-cli.dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: us-docker.pkg.dev/edgebit-containers/containers/nitro-cli:latest


### PR DESCRIPTION
Modify the nitro-cli container build workflow to build containers for both amd64 and arm.

This took some experimentation but seems to be working. An actual artifact pushed by this workflow:

![Screen Shot 2022-09-23 at 3 58 54 PM](https://user-images.githubusercontent.com/81445/192067335-8fbd8a35-5002-4877-8f89-c5f47a3ffb30.png)