### PR TITLE
Docs: add local guide

### DIFF
--- a/docs/deploy-local.md
+++ b/docs/deploy-local.md
@@ -7,7 +7,7 @@ weight: 30
 
 ## Running an Enclave Locally
 
-An app running with Enclaver starts as a source container image. In almost all cases, local development of your app can be done by running this container normally with Docker or another runtime.
+An app running with Enclaver starts as a source container image. In most cases, local development of your app can be done by running this container normally with Docker or another runtime.
 
 For testing the specific differences laid out below, see [Deploying on AWS][aws].
 


### PR DESCRIPTION
This guide has 2 goals:

1. confirm that you can just run your container locally with Docker and get the intended result
2. expand on the specific situations that will act differently