### PR TITLE
Basic compile & lint CI for Rust code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  clippy-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+      - uses: actions-rs/clippy@master
+        with:
+          args: --all-features --manifest-path enclaver/Cargo.toml
+
+
+  ## TODO: Add test job here?

--- a/enclaver/src/nitro_cli.rs
+++ b/enclaver/src/nitro_cli.rs
@@ -40,7 +40,7 @@ impl NitroCLI {
     }
 
     pub async fn run_enclave(&self, args: RunEnclaveArgs) -> Result<EnclaveInfo> {
-        Ok(self.run_and_deserialize_output(args).await?)
+        self.run_and_deserialize_output(args).await
     }
 
     pub async fn run_enclave_with_debug(&self, args: RunEnclaveArgs) -> Result<()> {
@@ -62,9 +62,9 @@ impl NitroCLI {
     }
 
     pub async fn describe_enclaves(&self) -> Result<Vec<EnclaveInfo>> {
-        Ok(self
+        self
             .run_and_deserialize_output(DescribeEnclavesArgs {})
-            .await?)
+            .await
     }
 
     pub async fn terminate_enclave(&self, enclave_id: &str) -> Result<()> {
@@ -81,13 +81,13 @@ impl NitroCLI {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EIFInfo {
     #[serde(rename = "Measurements")]
     measurements: EIFMeasurements,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EIFMeasurements {
     #[serde(rename = "PCR0")]
     pcr0: String,
@@ -99,7 +99,7 @@ pub struct EIFMeasurements {
     pcr2: String,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EnclaveInfo {
     #[serde(rename = "EnclaveName")]
     pub name: String,
@@ -111,7 +111,7 @@ pub struct EnclaveInfo {
     pub process_id: i32,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EnclaveTerminationStatus {
     #[serde(rename = "EnclaveID")]
     pub id: String,

--- a/enclaver/src/policy.rs
+++ b/enclaver/src/policy.rs
@@ -4,7 +4,7 @@ use tokio::fs::File;
 
 use tokio::io::AsyncReadExt;
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Policy {
     pub version: String,
     pub name: String,
@@ -12,13 +12,13 @@ pub struct Policy {
     pub ingress: Option<Vec<Ingress>>,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Ingress {
     pub listen_port: u16,
     pub tls: ServerTls,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ServerTls {
     pub key_file: String,
     pub cert_file: String,

--- a/enclaver/src/run.rs
+++ b/enclaver/src/run.rs
@@ -33,7 +33,7 @@ impl Enclave {
     }
 
     pub async fn start(&mut self) -> Result<EnclaveState> {
-        if let Some(_) = self.enclave_id {
+        if self.enclave_id.is_some() {
             return Err(anyhow!("Enclave already started"));
         }
 
@@ -51,7 +51,7 @@ impl Enclave {
 
         self.enclave_id = Some(enclave_info.id.clone());
 
-        Ok(EnclaveState::Running(enclave_info.id.clone()))
+        Ok(EnclaveState::Running(enclave_info.id))
     }
 
     pub async fn run_with_debug(&self) -> Result<()> {


### PR DESCRIPTION
Add GH Actions based CI for Rust code, and fix some of the lint issues identified.

This tests that code compiles, and uses clippy to lint it. It doesn't yet run any tests, etc.

I'm deliberately not touching most code I didn't write because I don't want to create merge conflicts. @eyakubovich at some point when its convenient for you, run `cargo clippy --fix` and it'll auto-fix most of the rest of its complaints.