### PR TITLE
Install odyn into EIFs, and connect to it from run-eif

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: ./.github/actions/cargo-zigbuild
         with:
           target: ${{ matrix.build-target }}
-          args: '--manifest-path enclaver/Cargo.toml --release'
+          args: '--manifest-path enclaver/Cargo.toml --release --all-features'
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -29,6 +29,7 @@ jobs:
             enclaver/target/${{ matrix.build-target }}/release/odyn
 
   publish-images:
+    if: github.repository == 'edgebitio/enclaver' && github.ref == 'refs/head/main'
     needs: build-release-binaries
     runs-on: ubuntu-latest
 

--- a/builder/dockerfiles/odyn-release.dockerfile
+++ b/builder/dockerfiles/odyn-release.dockerfile
@@ -3,4 +3,6 @@ ARG TARGETARCH
 
 COPY --from=artifacts ${TARGETARCH}/odyn /usr/local/bin/odyn
 
+RUN chmod 755 /usr/local/bin/odyn
+
 ENTRYPOINT ["/usr/local/bin/odyn"]

--- a/builder/dockerfiles/runtimebase.dockerfile
+++ b/builder/dockerfiles/runtimebase.dockerfile
@@ -3,4 +3,6 @@ ARG TARGETARCH
 
 COPY --from=artifacts ${TARGETARCH}/enclaver /usr/local/bin/enclaver
 
+RUN chmod 755 /usr/local/bin/enclaver
+
 ENTRYPOINT ["/usr/local/bin/enclaver", "run-eif", "--eif-file", "/enclave/application.eif"]

--- a/enclaver/Cargo.lock
+++ b/enclaver/Cargo.lock
@@ -261,6 +261,7 @@ dependencies = [
  "async-trait",
  "aws-nitro-enclaves-nsm-api",
  "bollard",
+ "bytes 1.2.1",
  "circbuf",
  "clap",
  "futures",

--- a/enclaver/Cargo.toml
+++ b/enclaver/Cargo.toml
@@ -3,13 +3,20 @@ name = "enclaver"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+name = "odyn"
+required-features = ["odyn"]
+
+[[bin]]
+name = "enclaver"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = { version = "1.0", features = ["std"] }
 tokio = { version = "1.20", features = ["full"] }
 tokio-pipe = "0.2"
-tokio-vsock = { git = "https://github.com/eyakubovich/tokio-vsock.git", rev = "8abc3b5c18d866a2d7f6c2f1fe0d835b49c85bd5" }
+tokio-vsock = { git = "https://github.com/eyakubovich/tokio-vsock.git", rev = "8abc3b5c18d866a2d7f6c2f1fe0d835b49c85bd5", optional = true }
 tokio-rustls = { version = "0.23", features = ["dangerous_configuration"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tokio-tar = "0.3"
@@ -32,12 +39,19 @@ http-body = "0.4"
 hyper = { version = "0.14", features = ["http1"] }
 uuid = { version = "1.0", features = ["v4"] }
 aws-nitro-enclaves-nsm-api = "0.2.1"
-rtnetlink = "0.11"
+rtnetlink = { version = "0.11", optional = true }
 circbuf = "0.2"
 async-trait = "0.1"
+bytes = "1.0"
 
 [dev-dependencies]
 assert2 = "0.3"
 json = "0.12"
 tls-listener = { version = "0.5", features = ["rustls", "hyper-h1"] }
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+
+[features]
+run_enclave = ["proxy"]
+odyn = ["vsock"]
+proxy = ["vsock"]
+vsock = ["dep:tokio-vsock", "dep:rtnetlink"]

--- a/enclaver/src/bin/odyn/config.rs
+++ b/enclaver/src/bin/odyn/config.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::collections::HashMap;
 use log::{debug};
 use anyhow::Result;
+use enclaver::constants::CONFIG_FILE_NAME;
 
 use enclaver::policy;
 use enclaver::tls;
@@ -16,7 +17,7 @@ pub struct Configuration {
 impl Configuration {
     pub async fn load<P: AsRef<Path>>(config_dir: P) -> Result<Self> {
         let mut policy_path = config_dir.as_ref().to_path_buf();
-        policy_path.push("policy.yaml");
+        policy_path.push(CONFIG_FILE_NAME);
 
         let policy = enclaver::policy::load_policy(policy_path.to_str().unwrap()).await?;
 

--- a/enclaver/src/bin/odyn/console.rs
+++ b/enclaver/src/bin/odyn/console.rs
@@ -381,6 +381,7 @@ mod tests {
     use tokio::io::{BufReader, Lines, AsyncBufRead, AsyncBufReadExt};
     use tokio_vsock::VsockStream;
     use anyhow::{Result, anyhow};
+    use enclaver::constants::STATUS_PORT;
 
     use super::{ByteLog, LogCursor};
     use crate::launcher::ExitStatus;
@@ -502,7 +503,7 @@ mod tests {
     }
 
     async fn app_status_lines() -> Result<Lines<impl AsyncBufRead + Unpin>> {
-        let sock = VsockStream::connect(enclaver::vsock::VMADDR_CID_HOST, 17000).await?;
+        let sock = VsockStream::connect(enclaver::vsock::VMADDR_CID_HOST, STATUS_PORT).await?;
         // bug in VsockStream::connect: it can return Ok even if connect failed
         _ = sock.peer_addr()?;
         Ok(BufReader::new(sock).lines())
@@ -511,7 +512,7 @@ mod tests {
     #[tokio::test]
     async fn test_app_status() {
         let app_status = super::AppStatus::new();
-        let status_task = app_status.start_serving(17000);
+        let status_task = app_status.start_serving(STATUS_PORT);
 
         let mut client1 = app_status_lines().await.unwrap();
         let mut client2 = app_status_lines().await.unwrap();

--- a/enclaver/src/bin/odyn/main.rs
+++ b/enclaver/src/bin/odyn/main.rs
@@ -13,12 +13,9 @@ use anyhow::{Result};
 
 use console::{AppLog, AppStatus};
 use config::Configuration;
+use enclaver::constants::{APP_LOG_PORT, STATUS_PORT};
 use ingress::IngressService;
 use egress::EgressService;
-
-// start "internal" ports above the 16-bit boundary (reserved for proxying TCP)
-const STATUS_PORT: u32 = 17000;
-const APP_LOG_PORT: u32 = 17001;
 
 #[derive(Parser)]
 struct CliArgs {

--- a/enclaver/src/constants.rs
+++ b/enclaver/src/constants.rs
@@ -1,0 +1,22 @@
+
+// Path and filename constants
+pub const CONFIG_FILE_NAME: &str = "policy.yaml";
+pub const ENCLAVE_CONFIG_DIR: &str = "/etc/enclaver";
+pub const ENCLAVE_ODYN_PATH: &str = "/sbin/odyn";
+
+
+
+
+// Port Constants
+
+// start "internal" ports above the 16-bit boundary (reserved for proxying TCP)
+pub const STATUS_PORT: u32 = 17000;
+pub const APP_LOG_PORT: u32 = 17001;
+
+
+
+
+
+
+
+

--- a/enclaver/src/lib.rs
+++ b/enclaver/src/lib.rs
@@ -3,10 +3,21 @@ extern crate core;
 pub mod build;
 
 mod images;
+
+pub mod constants;
+
 mod nitro_cli;
+
 pub mod policy;
+
+#[cfg(feature = "run_enclave")]
 pub mod run;
 
+#[cfg(feature = "proxy")]
 pub mod proxy;
+
+#[cfg(feature = "vsock")]
 pub mod vsock;
+
+#[cfg(feature = "proxy")]
 pub mod tls;


### PR DESCRIPTION
The basic goal of this branch is to:

1. Install odyn into EIFs and configure it as the entrypoint
2. Connect to odyn for log-shipping from `run-eif`

I ran into some issues along the way, so this also includes:

1. Adding in some feature flagging such that we can ship macOS builds. TL;DR is that if you invoke `run-eif` on macOS you'll get an error.
2. Some very basic logging. This has the side-effect of leaving CLI output in a weird halfway state; more to do here but its fine for now.
3. Improve some error messages.
4. Fix several `build` bugs.

There is more to do, but want to get this shipped and iterate in future PRs. Some of the highest priorities:
* Get the "release images" (images which bundle enclaver, nitro-cli, EIF and policy file) working. I think they might just work once a new runtimebase image is built after this merges.
* Improve CLI output - right now it is kind of a mix of different conventions.
* Improve signal handling in `run-eif` - currently Ctrl+C-ing a running enclave during the first few seconds of its life will kill the `run-eif` process but not the actual enclave (although this is a non-issue if you run `enclaver run-eif` in a container).
* Better self-cleanup during builds - right now we leave a lot of intermediate images and stuff lying around and they tend to fill up the filesystem.