### PR TITLE
Add egress network policy

### DIFF
--- a/enclaver/Cargo.lock
+++ b/enclaver/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "ipnetwork",
  "json",
  "log",
  "nix 0.24.2",
@@ -644,6 +645,15 @@ name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+
+[[package]]
+name = "ipnetwork"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "itoa"

--- a/enclaver/Cargo.toml
+++ b/enclaver/Cargo.toml
@@ -43,6 +43,7 @@ rtnetlink = { version = "0.11", optional = true }
 circbuf = "0.2"
 async-trait = "0.1"
 bytes = "1.0"
+ipnetwork = "0.20"
 
 [dev-dependencies]
 assert2 = "0.3"

--- a/enclaver/src/bin/enclaver/main.rs
+++ b/enclaver/src/bin/enclaver/main.rs
@@ -23,7 +23,7 @@ enum Commands {
     #[clap(name = "build")]
     Build {
         #[clap(long = "file", short = 'f')]
-        policy_file: String,
+        manifest_file: String,
 
         #[clap(long = "eif-only")]
         eif_file: Option<String>,
@@ -48,12 +48,12 @@ enum Commands {
 async fn run(args: Cli) -> Result<()> {
     match args.subcommand {
         Commands::Build {
-            policy_file,
+            manifest_file,
             eif_file: None,
         } => {
             let builder = EnclaveArtifactBuilder::new()?;
 
-            let (eif_info, release_img) = builder.build_release(&policy_file).await?;
+            let (eif_info, release_img) = builder.build_release(&manifest_file).await?;
 
             println!("Built Release Image: {}", release_img);
             println!("EIF Info: {:#?}", eif_info);
@@ -62,12 +62,12 @@ async fn run(args: Cli) -> Result<()> {
         }
 
         Commands::Build {
-            policy_file,
+            manifest_file,
             eif_file: Some(eif_file),
         } => {
             let builder = EnclaveArtifactBuilder::new()?;
 
-            let (eif_info, eif_path) = builder.build_eif_only(&policy_file, &eif_file).await?;
+            let (eif_info, eif_path) = builder.build_eif_only(&manifest_file, &eif_file).await?;
 
             println!("Built EIF: {}", eif_path.display());
             println!("EIF Info: {:#?}", eif_info);

--- a/enclaver/src/bin/odyn/config.rs
+++ b/enclaver/src/bin/odyn/config.rs
@@ -5,28 +5,28 @@ use log::{debug};
 use anyhow::Result;
 use enclaver::constants::CONFIG_FILE_NAME;
 
-use enclaver::policy;
+use enclaver::manifest::{self, Manifest};
 use enclaver::tls;
 
 pub struct Configuration {
     pub config_dir: PathBuf,
-    pub policy: policy::Policy,
+    pub manifest: Manifest,
     pub tls_server_configs: HashMap<u16, Arc<rustls::ServerConfig>>,
 }
 
 impl Configuration {
     pub async fn load<P: AsRef<Path>>(config_dir: P) -> Result<Self> {
-        let mut policy_path = config_dir.as_ref().to_path_buf();
-        policy_path.push(CONFIG_FILE_NAME);
+        let mut manifest_path = config_dir.as_ref().to_path_buf();
+        manifest_path.push(CONFIG_FILE_NAME);
 
-        let policy = enclaver::policy::load_policy(policy_path.to_str().unwrap()).await?;
+        let manifest = enclaver::manifest::load_manifest(manifest_path.to_str().unwrap()).await?;
 
         let mut tls_path = config_dir.as_ref().to_path_buf();
         tls_path.extend(["tls", "server"]);
 
         let mut tls_server_configs = HashMap::new();
 
-        if let Some(ref ingress) = policy.ingress {
+        if let Some(ref ingress) = manifest.ingress {
             for item in ingress {
                 let cfg = Configuration::load_tls_server_config(&tls_path, item)?;
                 tls_server_configs.insert(item.listen_port, cfg);
@@ -35,12 +35,12 @@ impl Configuration {
 
         Ok(Self{
             config_dir: config_dir.as_ref().to_path_buf(),
-            policy: policy,
+            manifest: manifest,
             tls_server_configs: tls_server_configs,
         })
     }
 
-    fn load_tls_server_config(tls_path: &Path, ingress: &policy::Ingress) -> Result<Arc<rustls::ServerConfig>> {
+    fn load_tls_server_config(tls_path: &Path, ingress: &manifest::Ingress) -> Result<Arc<rustls::ServerConfig>> {
         let mut ingress_path = tls_path.to_path_buf();
         ingress_path.push(&ingress.listen_port.to_string());
 

--- a/enclaver/src/lib.rs
+++ b/enclaver/src/lib.rs
@@ -7,7 +7,7 @@ mod images;
 pub mod constants;
 
 mod nitro_cli;
-
+pub mod manifest;
 pub mod policy;
 
 #[cfg(feature = "run_enclave")]

--- a/enclaver/src/manifest.rs
+++ b/enclaver/src/manifest.rs
@@ -5,7 +5,7 @@ use tokio::fs::File;
 use tokio::io::AsyncReadExt;
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct Policy {
+pub struct Manifest {
     pub version: String,
     pub name: String,
     pub image: String,
@@ -27,18 +27,21 @@ pub struct ServerTls {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Egress {
-    pub enabled: Option<bool>,
     pub proxy_port: Option<u16>,
     pub allow: Option<Vec<String>>,
+    pub deny: Option<Vec<String>>,
 }
 
-pub async fn load_policy(path: &str) -> Result<Policy> {
-    let mut file = File::open(path).await?;
+pub async fn load_manifest(path: &str) -> Result<Manifest> {
+    let mut file = match File::open(path).await {
+        Ok(file) => file,
+        Err(err) => return Err(anyhow::anyhow!("Failed to open {path}: {err}")),
+    };
     let mut buf = Vec::new();
 
     file.read_to_end(&mut buf).await?;
 
-    let policy: Policy = serde_yaml::from_slice(&buf)?;
+    let manifest: Manifest = serde_yaml::from_slice(&buf)?;
 
-    Ok(policy)
+    Ok(manifest)
 }

--- a/enclaver/src/policy/domain_filter.rs
+++ b/enclaver/src/policy/domain_filter.rs
@@ -1,0 +1,168 @@
+enum PatternPart {
+    Superwild,
+    Wild,
+    Named(String),
+}
+
+impl PatternPart {
+    fn new(part: &str) -> Self {
+        match part{
+            "**" => Self::Superwild,
+            "*" => Self::Wild,
+            _ => Self::Named(part.to_ascii_lowercase()),
+        }
+    }
+}
+
+struct Pattern(Vec<PatternPart>);
+
+impl Pattern{
+    fn new(pat: &str) -> Self {
+        let parts = pat.split('.')
+            .map(PatternPart::new)
+            .rev()
+            .collect();
+
+        Self(parts)
+    }
+
+    fn matches(&self, query: &Domain) -> bool {
+        let mut pat_iter = self.0.iter();
+        let mut q_iter = query.0.iter();
+
+        loop {
+            match pat_iter.next() {
+                Some(pat) => {
+                    let q = if let Some(q) = q_iter.next() { q } else { return false; };
+
+                    match pat {
+                        PatternPart::Superwild => return true,
+                        PatternPart::Wild => continue,
+                        PatternPart::Named(part) => if part == q { continue; } else { return false; },
+                    }
+                },
+                None => {
+                    // the pattern is exhausted, ensure that the q is also exhausted
+                    return q_iter.next().is_none();
+                }
+            }
+        }
+    }
+}
+
+struct Domain(Vec<String>);
+
+impl Domain {
+    fn new(dom: &str) -> Self {
+        let parts = dom.split('.')
+            .map(str::to_ascii_lowercase)
+            .rev()
+            .collect();
+
+        Self(parts)
+    }
+}
+
+pub struct DomainFilter {
+    patterns: Vec<Pattern>,
+}
+
+impl DomainFilter {
+    pub fn new() -> Self {
+        Self{
+            patterns: Vec::new()
+        }
+    }
+
+    pub fn allow_all() -> Self {
+        Self{
+            patterns: vec![Pattern::new("**")],
+        }
+    }
+
+    pub fn add(&mut self, pattern: &str) {
+        self.patterns.push(Pattern::new(pattern));
+    }
+
+    pub fn matches(&self, domain: &str) -> bool {
+        let dom = Domain::new(domain);
+
+        self.patterns.iter()
+            .any(|pat| pat.matches(&dom))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert2::assert;
+
+    use super::{Pattern, Domain, DomainFilter};
+
+    struct TestCase {
+        pattern: &'static str,
+        positives: Vec<&'static str>,
+        negatives: Vec<&'static str>,
+    }
+
+    #[test]
+    fn test_pattern_matching() {
+        let cases = vec![
+            TestCase{
+                pattern: "example.com",
+                positives: vec!["example.com", "Example.COM"],
+                negatives: vec!["example.net", ".example.com", "foo.com", "", "abc.example.com", "example."],
+            },
+            TestCase{
+                pattern: "*.com",
+                positives: vec!["example.com", "cnn.CoM", ],
+                negatives: vec!["example.net", "", "news.ycombinator.com", "beta.client1.saas.com", "example."],
+            },
+            TestCase{
+                pattern: "foo.*.com",
+                positives: vec!["foo.example.com"],
+                negatives: vec!["example.net", "", "example.", "foo.bar.example.com", ".com"],
+            },
+            TestCase{
+                pattern: "**.amazonaws.com",
+                positives: vec!["kms.us-east-1.amazonaws.com", "s3.amazonaws.com"],
+                negatives: vec!["amazonaws.com", "", "example.com"],
+            },
+        ];
+
+        for tc in &cases {
+            let pat = Pattern::new(tc.pattern);
+
+            let pos = tc.positives
+                .iter()
+                .map(|d| Domain::new(*d));
+
+            for d in pos {
+                assert!(pat.matches(&d));
+            }
+
+            let neg = tc.negatives
+                .iter()
+                .map(|d| Domain::new(*d));
+
+            for d in neg {
+                assert!(!pat.matches(&d));
+            }
+        }
+    }
+
+    #[test]
+    fn test_domain_filter() {
+        let mut df = DomainFilter::new();
+        df.add("example.com");
+        df.add("*.net");
+        df.add("foo.*.com");
+        df.add("**.amazonaws.com");
+
+        assert!(df.matches("example.com"));
+        assert!(!df.matches("cnn.com"));
+        assert!(df.matches("example.net"));
+        assert!(!df.matches("foo.bar.org"));
+        assert!(df.matches("kms.amazonaws.com"));
+        assert!(df.matches("kms.us-east-1.amazonaws.com"));
+    }
+}

--- a/enclaver/src/policy/ip_filter.rs
+++ b/enclaver/src/policy/ip_filter.rs
@@ -1,0 +1,136 @@
+use std::net::IpAddr;
+
+use anyhow::Result;
+use ipnetwork::IpNetwork;
+
+#[derive(Debug)]
+struct Pattern(IpNetwork);
+
+impl Pattern {
+    fn new(pattern: &str) -> Result<Self> {
+        let ipn: IpNetwork = pattern.parse()?;
+        Ok(Pattern(ipn))
+    }
+
+    fn matches(&self, addr: IpAddr) -> bool {
+        self.0.contains(addr)
+    }
+}
+
+pub struct IpFilter {
+    patterns: Vec<Pattern>,
+}
+
+impl IpFilter {
+    pub fn new() -> Self {
+        Self{
+            patterns: Vec::new(),
+        }
+    }
+
+    pub fn allow_all() -> Self {
+        Self{
+            patterns: vec![
+                Pattern::new("0.0.0.0/0").unwrap(),
+                Pattern::new("::/0").unwrap()
+            ],
+        }
+    }
+
+    pub fn add(&mut self, pattern: &str) -> Result<()> {
+        self.patterns.push(Pattern::new(pattern)?);
+        Ok(())
+    }
+
+    pub fn matches(&self, addr: IpAddr) -> bool {
+        self.patterns.iter()
+            .any(|p| p.matches(addr))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+    use assert2::assert;
+
+    use super::{Pattern, IpFilter};
+
+    struct TestCase {
+        pattern: &'static str,
+        positives: Vec<&'static str>,
+        negatives: Vec<&'static str>,
+    }
+
+    #[test]
+    fn test_pattern_matching() {
+        let cases = vec![
+            TestCase{
+                pattern: "66.254.33.22",
+                positives: vec!["66.254.33.22"],
+                negatives: vec!["66.254.33.21"],
+            },
+            TestCase{
+                pattern: "66.254.33.22/32",
+                positives: vec!["66.254.33.22"],
+                negatives: vec!["66.254.33.21", "66.254.33.23"],
+            },
+            TestCase{
+                pattern: "0.0.0.0/0",
+                positives: vec!["66.254.33.22", "1.2.3.4", "255.255.255.255"],
+                negatives: vec![],
+            },
+            TestCase{
+                pattern: "66.254.33.22/24",
+                positives: vec!["66.254.33.1", "66.254.33.22", "66.254.33.255"],
+                negatives: vec!["66.254.34.1", "67.254.33.22", "66.254.32.255"],
+            },
+            TestCase{
+                pattern: "::/0",
+                positives: vec!["::", "fc00::1234", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"],
+                negatives: vec![],
+            },
+            // TODO: support IPv4 addresses encoded in IPv6
+            // TestCase{
+            //    pattern: "::ffff:42fe:2116/124",
+            //    positives: vec!["66.254.33.1", "66.254.33.22", "66.254.33.255"],
+            //    negatives: vec!["66.254.34.1", "67.254.33.22", "66.254.32.255"],
+            // },
+        ];
+
+        for tc in &cases {
+            let pat = Pattern::new(tc.pattern).unwrap();
+
+            let pos = tc.positives
+                .iter()
+                .map(|a| a.parse::<IpAddr>().unwrap());
+
+            for a in pos {
+                println!("pattern={:?}, addr={}", pat, a);
+                assert!(pat.matches(a));
+            }
+
+            let neg = tc.negatives
+                .iter()
+                .map(|a| a.parse::<IpAddr>().unwrap());
+
+            for a in neg {
+                assert!(!pat.matches(a));
+            }
+        }
+    }
+
+    #[test]
+    fn test_ip_filter() {
+        let mut df = IpFilter::new();
+        df.add("66.254.33.22").unwrap();
+        df.add("66.254.34.22/32").unwrap();
+        df.add("66.254.35.0/24").unwrap();
+
+        assert!(df.matches("66.254.33.22".parse().unwrap()));
+        assert!(df.matches("66.254.34.22".parse().unwrap()));
+        assert!(df.matches("66.254.35.22".parse().unwrap()));
+        assert!(!df.matches("66.254.33.21".parse().unwrap()));
+        assert!(!df.matches("66.254.34.23".parse().unwrap()));
+        assert!(!df.matches("66.254.36.23".parse().unwrap()));
+    }
+}

--- a/enclaver/src/policy/mod.rs
+++ b/enclaver/src/policy/mod.rs
@@ -1,0 +1,66 @@
+pub mod domain_filter;
+pub mod ip_filter;
+
+use std::net::IpAddr;
+
+use domain_filter::DomainFilter;
+use ip_filter::IpFilter;
+
+pub struct EgressPolicy {
+    domain_allow: DomainFilter,
+    domain_deny: DomainFilter,
+    ip_allow: IpFilter,
+    ip_deny: IpFilter,
+}
+
+impl EgressPolicy {
+    pub fn new(spec: &crate::manifest::Egress) -> Self {
+        let (domain_allow, ip_allow) = load_filters(&spec.allow);
+        let (domain_deny, ip_deny) = load_filters(&spec.deny);
+
+        Self {
+            domain_allow: domain_allow,
+            domain_deny: domain_deny,
+            ip_allow: ip_allow,
+            ip_deny: ip_deny,
+        }
+    }
+
+    pub fn allow_all() -> Self {
+        Self {
+            domain_allow: DomainFilter::allow_all(),
+            domain_deny: DomainFilter::new(),
+            ip_allow: IpFilter::allow_all(),
+            ip_deny: IpFilter::new(),
+        }
+    }
+
+    pub fn is_host_allowed(&self, mut host: &str) -> bool {
+        log::trace!("is_host_allowed({host})");
+
+        // An IPv6 address gets passed with the brackets, e.g. [::1],
+        // and need to be stripped before converting to an IpAddr
+        host = host.strip_prefix('[').unwrap_or(host);
+        host = host.strip_suffix(']').unwrap_or(host);
+
+        match host.parse::<IpAddr>() {
+            Ok(addr) => self.ip_allow.matches(addr) && !self.ip_deny.matches(addr),
+            Err(_) => self.domain_allow.matches(host) && !self.domain_deny.matches(host),
+        }
+    }
+}
+
+fn load_filters(opt_spec: &Option<Vec<String>>) -> (DomainFilter, IpFilter) {
+    let mut domains = DomainFilter::new();
+    let mut ips = IpFilter::new();
+
+    if let Some(ref spec) = opt_spec {
+        for pattern in spec {
+            if ips.add(pattern).is_err() {
+                domains.add(pattern);
+            }
+        }
+    }
+
+    (domains, ips)
+}

--- a/enclaver/src/proxy/ingress.rs
+++ b/enclaver/src/proxy/ingress.rs
@@ -104,6 +104,7 @@ mod tests {
     use tokio_rustls::TlsConnector;
     use anyhow::Result;
     use rustls::ServerName;
+    use assert2::assert;
 
     use super::{EnclaveProxy, HostProxy};
 


### PR DESCRIPTION
- Renames policy.yaml to enclaver.yaml
- Renames policy module to manifest
- The policy is specified in enclaver.yaml as:
```
egress:
  allow: ["*.example.com", "**.foo.net", "10.0.5.0/24"]
  deny: ["foo.example.com", "10.0.5.5"]
```
- The policy is deny default