### PR TITLE
Fix Odyn Args Generation

### DIFF
--- a/enclaver/src/build.rs
+++ b/enclaver/src/build.rs
@@ -124,6 +124,7 @@ impl EnclaveArtifactBuilder {
             String::from(ENCLAVE_ODYN_PATH),
             String::from("--config-dir"),
             String::from("/etc/enclaver"),
+            String::from("--"),
         ];
 
         odyn_command.append(&mut entrypoint);


### PR DESCRIPTION
Insert a `--` before positional args to odyn.