### PR TITLE
Tag release images on build

### DIFF
--- a/enclaver/src/bin/enclaver/main.rs
+++ b/enclaver/src/bin/enclaver/main.rs
@@ -53,9 +53,9 @@ async fn run(args: Cli) -> Result<()> {
         } => {
             let builder = EnclaveArtifactBuilder::new()?;
 
-            let (eif_info, release_img) = builder.build_release(&policy_file).await?;
+            let (eif_info, release_img, tag) = builder.build_release(&policy_file).await?;
 
-            println!("Built Release Image: {}", release_img);
+            println!("Built Release Image: {release_img} ({tag})");
             println!("EIF Info: {:#?}", eif_info);
 
             Ok(())

--- a/enclaver/src/build.rs
+++ b/enclaver/src/build.rs
@@ -49,12 +49,14 @@ impl EnclaveArtifactBuilder {
     }
 
     /// Build a release image based on the referenced policy.
-    pub async fn build_release(&self, policy_path: &str) -> Result<(EIFInfo, ImageRef)> {
-        let (_policy, build_dir, eif_info) = self.common_build(policy_path).await?;
+    pub async fn build_release(&self, policy_path: &str) -> Result<(EIFInfo, ImageRef, String)> {
+        let (policy, build_dir, eif_info) = self.common_build(policy_path).await?;
         let eif_path = build_dir.path().join(EIF_FILE_NAME);
         let release_img = self.package_eif(eif_path, policy_path).await?;
 
-        Ok((eif_info, release_img))
+        self.image_manager.tag_image(&release_img, &policy.name).await?;
+
+        Ok((eif_info, release_img, policy.name.to_string()))
     }
 
     /// Build an EIF, as would be included in a release image, based on the referenced policy.

--- a/example/policy.yaml
+++ b/example/policy.yaml
@@ -1,18 +1,3 @@
 version: v1
-image: "example:latest"
+image: "no-fly-list:latest"
 name: "example-enclave"
-resources:
-  cpus: 2
-  memory: 1024
-network:
-  listen_ports:
-    - 8080
-  egress:
-    - host: 169.254.169.254
-      port: 80
-    - host: kms.us-west-2.amazonaws.com
-      port: 443
-    - host: google.com
-      port: 443
-    - host: www.google.com
-      port: 443


### PR DESCRIPTION
Tag release images with the `name` field from the YAML config (did we want to rename this? I've lost track).

While I'm at it, updated the example policy.yaml file I've been using.