### PR TITLE
Fix a typo that is preventing image publishing job from running

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
             enclaver/target/${{ matrix.build-target }}/release/odyn
 
   publish-images:
-    if: github.repository == 'edgebitio/enclaver' && github.ref == 'refs/head/main'
+    if: github.repository == 'edgebitio/enclaver' && github.ref == 'refs/heads/main'
     needs: build-release-binaries
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This guard is arguably redundant with the branch restriction at the top of the file, but:

1. Does help with pushes to forks, where this workflow tries to run
2. Prevents accidents if we ever change the restriction at the top of the file

So, fix the typo.