### PR TITLE
Docs: add getting started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Enclaves provide several critical features for operating software which processe
 
 These demos show off how your apps can use these unique features to improve privacy and security:
 
- - TODO: update this list
  - [Run a simple Python app](docs/guide-app.md) that represents a microservice or security-centric function
  - [Run Hashicorp Vault](docs/guide-vault.md) to fully isolate it after it's unsealed
 
@@ -18,6 +17,7 @@ These demos show off how your apps can use these unique features to improve priv
 
 Enclaver is currently in alpha and not intended for use in production. Enclaver currently only supports [AWS Nitro Enclaves](https://aws.amazon.com/ec2/nitro/nitro-enclaves/); support for Azure Confidential VMs, GCP Confidential VMs, and arbitrary SGX and OP-TEE enclaves is on the roadmap.
 
+ - [Getting started guide](docs/getting-started.md)
  - [Deploy an enclave on AWS](docs/deploy-aws.md)
  - [Deploy locally for development](docs/deploy-local.md)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,39 @@
+---
+title: "Getting Started with Enclaver"
+layout: docs-enclaver-single
+aliases:
+    - /enclaver/docs/
+    - /enclaver/docs/0.x/
+---
+
+# Getting Started with Enclaver
+
+Enclaver is an open source toolkit created to enable easy adoption of software enclaves, for new and existing backend software.
+
+Enclaves provide several critical features for operating software which processes sensitive data, including isolation, attestation and network restrictions.
+
+<img src="img/diagram-enclaver-components.svg" width="800" />
+
+Refer to [the architecture](architecture.md) for a complete understanding of Enclaver components.
+
+## Tutorials
+
+### [No-Fly-List Python app][no-fly-app]
+
+Deploy the No-Fly-List app, which checks passengers attempting to fly on an airline against a no-fly list. It’s a fairly simple Python application that requires protection “in-use” for its data, because we don’t want anyone to be able to see the full no-fly list.
+
+This guide is applicable to any microservice or security-centric function at your organization.
+
+### [Hashicorp Vault][vault]
+
+Run Hashicorp Vault within an enclave to fully isolate it after it's unsealed.
+
+This guide is model for running off-the-shelf or commercial software in an enclave.
+
+### [Deploy on AWS][aws]
+
+Straightforward guide to getting started with Enclaver on AWS with EC2 machines that are enabled to run Nitro Enclaves.
+
+[no-fly-app]: guide-app.md
+[vault]: guide-vault.md
+[aws]: deploy-aws.md


### PR DESCRIPTION
Add getting started guide as the entry point to the docs. Overview of architecture with deeper link, and pointers to the main 3 guides.