### PR TITLE
Various usability improvements related to building and running enclaves

### DIFF
--- a/build/dockerfiles/runtimebase-dev.dockerfile
+++ b/build/dockerfiles/runtimebase-dev.dockerfile
@@ -2,4 +2,4 @@ FROM edgebitio/nitro-cli:latest
 
 COPY ./enclaver /usr/local/bin/enclaver
 
-ENTRYPOINT ["/usr/local/bin/enclaver", "run-eif", "--eif-file", "/enclave/application.eif"]
+ENTRYPOINT ["/usr/local/bin/enclaver", "run-eif"]

--- a/build/dockerfiles/runtimebase.dockerfile
+++ b/build/dockerfiles/runtimebase.dockerfile
@@ -3,4 +3,4 @@ ARG TARGETARCH
 
 COPY --from=artifacts ${TARGETARCH}/enclaver /usr/local/bin/enclaver
 
-ENTRYPOINT ["/usr/local/bin/enclaver", "run-eif", "--eif-file", "/enclave/application.eif"]
+ENTRYPOINT ["/usr/local/bin/enclaver", "run-eif"]

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -52,11 +52,11 @@ Runs the given EIF file as an enclave without starting the outside components. U
 
 | Flag | Type | Description |
 |:-----|:-----|:------------|
-| `--eif-file` | String | Path on disk to EIF file to run. |
-| `--manifest-file` | String | Path on disk to the manifest file used to generate the EIF. |
-| `--cpu-count` | Int | Number of CPUs dedicated to the enclave. |
-| `--memory-mb` | Int | Megabytes of memory dedicated to the enclave. |
-| `--debug-mode` | Boolean (Default=false) | Enable debug mode on the enclave, which grants access to streaming logs from within. |
+| `--eif-file` | String (Default="/enclave/application.eif") | Path on disk to EIF file to run. |
+| `--manifest-file` | String (Default="/enclave/enclaver.yaml") | Path on disk to the manifest file used to generate the EIF. |
+| `--cpu-count` | Int (Default=2) | Number of CPUs dedicated to the enclave. Defaults to 2, unless another default is specified in the manifest. |
+| `--memory-mb` | Int (Default=4096) | Megabytes of memory dedicated to the enclave. Defaults to 4096, unless another default is specified in the manifest. |
+| `--debug-mode` | Boolean (Default=false) | Enable debug mode on the enclave, and translate its console output to log lines. |
 
 
 [format]: architecture.md#enclaver-image-format

--- a/enclaver/src/bin/odyn/config.rs
+++ b/enclaver/src/bin/odyn/config.rs
@@ -1,9 +1,9 @@
-use std::path::{PathBuf, Path};
-use std::sync::Arc;
-use std::collections::HashMap;
-use log::{debug};
 use anyhow::Result;
-use enclaver::constants::CONFIG_FILE_NAME;
+use enclaver::constants::MANIFEST_FILE_NAME;
+use log::debug;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use enclaver::manifest::{self, Manifest};
 use enclaver::tls;
@@ -23,7 +23,7 @@ pub enum ListenerConfig {
 impl Configuration {
     pub async fn load<P: AsRef<Path>>(config_dir: P) -> Result<Self> {
         let mut manifest_path = config_dir.as_ref().to_path_buf();
-        manifest_path.push(CONFIG_FILE_NAME);
+        manifest_path.push(MANIFEST_FILE_NAME);
 
         let manifest = enclaver::manifest::load_manifest(manifest_path.to_str().unwrap()).await?;
 
@@ -46,14 +46,17 @@ impl Configuration {
             }
         }
 
-        Ok(Self{
+        Ok(Self {
             config_dir: config_dir.as_ref().to_path_buf(),
             manifest: manifest,
             listener_configs,
         })
     }
 
-    fn load_tls_server_config(tls_path: &Path, ingress: &manifest::Ingress) -> Result<Arc<rustls::ServerConfig>> {
+    fn load_tls_server_config(
+        tls_path: &Path,
+        ingress: &manifest::Ingress,
+    ) -> Result<Arc<rustls::ServerConfig>> {
         let mut ingress_path = tls_path.to_path_buf();
         ingress_path.push(&ingress.listen_port.to_string());
 

--- a/enclaver/src/bin/odyn/main.rs
+++ b/enclaver/src/bin/odyn/main.rs
@@ -82,12 +82,12 @@ async fn run(args: &CliArgs) -> Result<()> {
 
 #[tokio::main]
 async fn main() {
-    pretty_env_logger::init();
+    enclaver::utils::init_logging();
 
     let args = CliArgs::parse();
 
     if let Err(err) = run(&args).await {
-        error!("Error: {}", err);
+        error!("Error: {err:#}");
         std::process::exit(1);
     }
 }

--- a/enclaver/src/constants.rs
+++ b/enclaver/src/constants.rs
@@ -1,11 +1,11 @@
-
 // Path and filename constants
-pub const CONFIG_FILE_NAME: &str = "enclaver.yaml";
+pub const EIF_FILE_NAME: &str = "application.eif";
+pub const MANIFEST_FILE_NAME: &str = "enclaver.yaml";
+
 pub const ENCLAVE_CONFIG_DIR: &str = "/etc/enclaver";
 pub const ENCLAVE_ODYN_PATH: &str = "/sbin/odyn";
 
-
-
+pub const RELEASE_BUNDLE_DIR: &str = "/enclave";
 
 // Port Constants
 

--- a/enclaver/src/lib.rs
+++ b/enclaver/src/lib.rs
@@ -23,3 +23,5 @@ pub mod vsock;
 
 #[cfg(feature = "proxy")]
 pub mod tls;
+
+pub mod utils;

--- a/enclaver/src/utils.rs
+++ b/enclaver/src/utils.rs
@@ -1,0 +1,49 @@
+use anyhow::{anyhow, Result};
+use futures_util::stream::StreamExt;
+use log::info;
+use std::path::PathBuf;
+use tokio::io::AsyncRead;
+use tokio_util::codec::{FramedRead, LinesCodec};
+
+const LOG_LINE_MAX_LEN: usize = 4 * 1024;
+
+pub fn init_logging() {
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "info");
+    }
+    pretty_env_logger::init();
+}
+
+pub trait StringablePathExt {
+    fn must_to_str(&self) -> Result<&str>;
+    fn must_to_string(&self) -> Result<String>;
+}
+
+impl StringablePathExt for PathBuf {
+    fn must_to_str(&self) -> Result<&str> {
+        self.to_str()
+            .ok_or_else(|| anyhow!("filename contains non-UTF-8 characters"))
+    }
+
+    fn must_to_string(&self) -> Result<String> {
+        self.to_str()
+            .ok_or_else(|| anyhow!("filename contains non-UTF-8 characters"))
+            .map(|s| s.to_string())
+    }
+}
+
+pub async fn log_lines_from_stream<S>(target: &str, stream: S) -> Result<()>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut framed = FramedRead::new(stream, LinesCodec::new_with_max_length(LOG_LINE_MAX_LEN));
+
+    while let Some(line_res) = framed.next().await {
+        match line_res {
+            Ok(line) => info!(target: target, "{line}"),
+            Err(e) => info!(target: target, "error reading log stream: {e}"),
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
* Make all flags to run-eif optional, with defaults
* Allow overriding CPU count and memory defaults via a 'defaults' section in enclaver.yaml
* Attach to console in --debug-mode and translate output into log lines
* Connect to odyn status port, and shut down run-eif when Odyn reports exit
* Refactor run-eif signal handling to avoid indefinite hanging
* Translate nitro-cli output to log lines when building EIFs
* Clean up compiler output when building with --all-features
* Default Odyn to log at INFO
* Make Odyn exit errors more verbose
* Minor logging cleanup to enhance default experience