### PR TITLE
Minor CLI UX improvements

### DIFF
--- a/enclaver/src/bin/enclaver/main.rs
+++ b/enclaver/src/bin/enclaver/main.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use enclaver::build::EnclaveArtifactBuilder;
 #[cfg(feature = "run_enclave")]
 use enclaver::run::{Enclave, EnclaveOpts};
-use enclaver::build::EnclaveArtifactBuilder;
 use log::{debug, error, info};
 use std::{future::Future, path::PathBuf};
 use tokio::signal::unix::{signal, SignalKind};
@@ -18,7 +18,7 @@ struct Cli {
 enum Commands {
     #[clap(name = "build")]
     Build {
-        #[clap(long = "file", short = 'f')]
+        #[clap(long = "file", short = 'f', default_value = "enclaver.yaml")]
         manifest_file: String,
 
         #[clap(long = "eif-only")]
@@ -109,7 +109,7 @@ async fn run(args: Cli) -> Result<()> {
                 },
             }
 
-            enclave.stop().await?;
+            enclave.cleanup().await?;
 
             Ok(())
         }


### PR DESCRIPTION
A few minor things:

1. If nitro-cli prints one of two known errors (out of disk space, or the cryptic image-too-big-for-memory one), log a warning with additional info. I'm not in love with this display format, but its good enough for now.
2. Remove some intermediate build stuff that was left laying around in docker, especially the UUID-tagged containers. In practice these just have a fairly small layer on top of the underlying image, so probably weren't taking up as much space as it looked like - but when you _do_ run out of disk space this is much nicer than seeing dozens of weird images laying around.
3. Default `-f` to `enclaver.yaml` - meaning you can now simply run `enclaver build` in a directory with a manifest file, and it'll just work.


