### PR TITLE
Fix logging initialization

### DIFF
--- a/enclaver/src/bin/enclaver/main.rs
+++ b/enclaver/src/bin/enclaver/main.rs
@@ -144,12 +144,6 @@ async fn register_shutdown_signal_handler() -> Result<impl Future> {
 async fn main() {
     enclaver::utils::init_logging();
 
-    // This is kind of a hack...
-    if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "info");
-    }
-
-    pretty_env_logger::init();
     let args = Cli::parse();
 
     if let Err(err) = run(args).await {


### PR DESCRIPTION
Looks like we're double-initializing logging now, probably as a result of a merge.