### PR TITLE
Add unit tests for KMS proxy and PKCS7

### DIFF
--- a/enclaver/Cargo.toml
+++ b/enclaver/Cargo.toml
@@ -69,6 +69,7 @@ sha2 = "0.10"
 assert2 = "0.3"
 tls-listener = { version = "0.5", features = ["rustls", "hyper-h1"] }
 reqwest = { version = "=0.11.6", default-features = false, features = ["rustls-tls-webpki-roots"] }
+aws-types = { version = "0.49", features = ["hardcoded-credentials"] }
 
 [features]
 run_enclave = ["proxy"]

--- a/enclaver/src/keypair.rs
+++ b/enclaver/src/keypair.rs
@@ -19,6 +19,15 @@ impl KeyPair {
         Ok(KeyPair{ private, public })
     }
 
+    pub fn from_private(private: RsaPrivateKey) -> Self {
+        let public = private.to_public_key();
+
+        Self{
+            private,
+            public,
+        }
+    }
+
     pub fn public_key_as_der(&self) -> Result<Vec<u8>> {
         Ok(self.public.to_public_key_der()?.into_vec())
     }


### PR DESCRIPTION
To make many of the componenets mockable, some setup code was moved from KmsProxy and into KmsProxyService in odyn.