### PR TITLE
Run app as root and add "host" alias

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -216,6 +216,8 @@ For ingress, TLS is terminated and ingress policy is enforced. The private keys 
 
 For egress, policy is enforced before traffic leaves the enclave.
 
+The `host` hostname can refer to localhost on the parent instance of the enclave, which is useful for egress traffic to stay local to the machine, like talking to other containers running outside the enclave.
+
 The inner proxy can optionally append the attestation of the enclave to `Decrypt`, `GenerateDataKey`, and `GenerateRandom` calls to AWS KMS, which allows for super easy integration for your code to use your KMS keys to decrypt data within the enclave. This is when you see the power of using the output from `enclaver trust --kms` as part of a KMS key policy.
 
 TODO: update with final enclaver trust command. See [issue #38](https://github.com/edgebitio/enclaver/issues/38).

--- a/enclaver/src/bin/odyn/main.rs
+++ b/enclaver/src/bin/odyn/main.rs
@@ -63,8 +63,8 @@ async fn run(args: &CliArgs) -> Result<()> {
     let kms_proxy = KmsProxyService::start(config.clone(), nsm.clone()).await?;
 
     let creds = launcher::Credentials{
-        uid: 100,
-        gid: 100,
+        uid: 0,
+        gid: 0,
     };
 
     info!("Starting {:?}", args.entrypoint);

--- a/enclaver/src/constants.rs
+++ b/enclaver/src/constants.rs
@@ -17,3 +17,6 @@ pub const HTTP_EGRESS_VSOCK_PORT: u32 = 17002;
 // Default TCP Port that the egress proxy listens on inside the enclave, if not
 // specified in the manifest.
 pub const HTTP_EGRESS_PROXY_PORT: u16 = 9000;
+
+// The hostname to refer to the host side from inside the enclave.
+pub const OUTSIDE_HOST: &str = "host";


### PR DESCRIPTION
- To facilitate apps such as Vault that require some additional capabilites, run the app as root until
a more fine grained capability filter is added

- "localhost" should refer to the inside of the enclave, add "host" to refer to the outside.