### PR TITLE
Add validation and grouping to CloudFormation

### DIFF
--- a/docs/assets/enclaver.cloudformation-arm.yaml
+++ b/docs/assets/enclaver.cloudformation-arm.yaml
@@ -4,20 +4,25 @@ Parameters:
   VpcId:
     Type: AWS::EC2::VPC::Id
     Description: Existing VPC to place the machine
+    AllowedPattern: ".+"
   SubnetId:
     Type: AWS::EC2::Subnet::Id
     Description: Subnet within the VPC to place the machine
+    AllowedPattern: ".+"
   InstanceType:
     Type: String
     Description: Cheapest Gravitron2 instance that supports Nitro Enclaves
     Default: c6g.large
+    AllowedPattern: ".+"
   KeyName:
     Description: SSH Keypair to login to the instance
     Type: AWS::EC2::KeyPair::KeyName
+    AllowedPattern: ".+"
   LatestAmiId:
     Description: Amazon Linux 2 Arm AMI for us-east1 Region
     Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
     Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-arm64-gp2'
+    AllowedPattern: ".+"
 Resources:
   DemoLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate

--- a/docs/assets/enclaver.cloudformation-arm.yaml
+++ b/docs/assets/enclaver.cloudformation-arm.yaml
@@ -1,5 +1,30 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Test Enclaver on a single EC2 machine with Nitro Enclaves enabled
+Metadata: 
+  AWS::CloudFormation::Interface: 
+    ParameterGroups: 
+      - Label: 
+          default: "VPC Configuration"
+        Parameters: 
+          - VpcId
+          - SubnetId
+      - Label: 
+          default: "EC2 Machine"
+        Parameters: 
+          - InstanceType
+          - KeyName
+          - LatestAmiId
+    ParameterLabels: 
+      VpcId: 
+        default: "Pick a VPC"
+      SubnetId: 
+        default: "Pick a subnet"
+      InstanceType: 
+        default: "Instance type"
+      KeyName: 
+        default: "SSH key"
+      LatestAmiId: 
+        default: "AMI to use"
 Parameters:
   VpcId:
     Type: AWS::EC2::VPC::Id

--- a/docs/assets/enclaver.cloudformation-x86.yaml
+++ b/docs/assets/enclaver.cloudformation-x86.yaml
@@ -1,5 +1,30 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Test Enclaver on a single EC2 machine with Nitro Enclaves enabled
+Metadata: 
+  AWS::CloudFormation::Interface: 
+    ParameterGroups: 
+      - Label: 
+          default: "VPC Configuration"
+        Parameters: 
+          - VpcId
+          - SubnetId
+      - Label: 
+          default: "EC2 Machine"
+        Parameters: 
+          - InstanceType
+          - KeyName
+          - LatestAmiId
+    ParameterLabels: 
+      VpcId: 
+        default: "Pick a VPC"
+      SubnetId: 
+        default: "Pick a subnet"
+      InstanceType: 
+        default: "Instance type"
+      KeyName: 
+        default: "SSH key"
+      LatestAmiId: 
+        default: "AMI to use"
 Parameters:
   VpcId:
     Type: AWS::EC2::VPC::Id

--- a/docs/assets/enclaver.cloudformation-x86.yaml
+++ b/docs/assets/enclaver.cloudformation-x86.yaml
@@ -4,20 +4,25 @@ Parameters:
   VpcId:
     Type: AWS::EC2::VPC::Id
     Description: Existing VPC to place the machine
+    AllowedPattern: ".+"
   SubnetId:
     Type: AWS::EC2::Subnet::Id
     Description: Subnet within the VPC to place the machine
+    AllowedPattern: ".+"
   InstanceType:
     Type: String
     Description: Cheapest x86 instance that supports Nitro Enclaves
     Default: c6a.xlarge
+    AllowedPattern: ".+"
   KeyName:
     Description: SSH Keypair to login to the instance
     Type: AWS::EC2::KeyPair::KeyName
+    AllowedPattern: ".+"
   LatestAmiId:
     Description: Amazon Linux 2 x86 AMI for us-east1 Region
     Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
     Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
+    AllowedPattern: ".+"
 Resources:
   DemoLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate


### PR DESCRIPTION
The only way to enforce ordering is to use groups, so this adds them.

The only way to mark something as required is to use regex, so this adds a "is not empty" equivalent regex.