### PR TITLE
Report errors that occur during startup

### DIFF
--- a/enclaver/src/bin/enclaver-run/main.rs
+++ b/enclaver/src/bin/enclaver-run/main.rs
@@ -9,6 +9,7 @@ use std::{
 use tokio_util::sync::CancellationToken;
 
 const ENCLAVE_SIGNALED_EXIT_CODE: u8 = 107;
+const ENCLAVE_FATAL: u8 = 108;
 const ENCLAVER_INTERRUPTED: u8 = 109;
 
 #[derive(Debug, Parser)]
@@ -42,6 +43,9 @@ impl Termination for CLISuccess {
             }
             CLISuccess::EnclaveStatus(EnclaveExitStatus::Signaled(_signal)) => {
                 ExitCode::from(ENCLAVE_SIGNALED_EXIT_CODE)
+            }
+            CLISuccess::EnclaveStatus(EnclaveExitStatus::Fatal(_err)) => {
+                ExitCode::from(ENCLAVE_FATAL)
             }
             CLISuccess::EnclaveStatus(EnclaveExitStatus::Cancelled) => {
                 ExitCode::from(ENCLAVER_INTERRUPTED)


### PR DESCRIPTION
If an error occured before the entrypoint successfully runs, odyn would exit and no good feedback would be given.

Now odyn brings up status & logs endpoints first thing and then stays up in case of errors. It reports a Fatal status along with the message. Enclaver is able to read all the logs and print the final status.