### PR TITLE
Revamp Internal Dependency Management

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,6 +106,19 @@ jobs:
         run: |
           gcloud auth configure-docker us-docker.pkg.dev
 
+      - name: Generate Odyn Image Metadata
+        id: odyn-metadata
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            us-docker.pkg.dev/edgebit-containers/containers/odyn
+          tags: |
+            type=sha,
+            type=semver,pattern=v{{major}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+
       - name: Build Odyn Image
         uses: docker/build-push-action@v3
         with:
@@ -114,7 +127,20 @@ jobs:
           file: odyn-release.dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: us-docker.pkg.dev/edgebit-containers/containers/odyn:latest
+          tags: ${{ steps.odyn-meta.outputs.tags }}
+
+      - name: Generate Runtime Base Image Metadata
+        id: wrapper-base-metadata
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            us-docker.pkg.dev/edgebit-containers/containers/enclaver-wrapper-base
+          tags: |
+            type=sha,
+            type=semver,pattern=v{{major}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
 
       - name: Build Runtime Base Image
         uses: docker/build-push-action@v3
@@ -124,9 +150,9 @@ jobs:
           file: runtimebase.dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: us-docker.pkg.dev/edgebit-containers/containers/enclaver-wrapper-base:latest
+          tags: ${{ steps.wrapper-base-meta.outputs.tags }}
 
-  create-release:
+  upload-release-artifact:
     if: github.repository == 'edgebitio/enclaver' && github.ref_type == 'tag'
     needs: build-release-binaries
     runs-on: ubuntu-latest

--- a/enclaver/src/images.rs
+++ b/enclaver/src/images.rs
@@ -4,7 +4,7 @@ use bollard::image::{BuildImageOptions, CreateImageOptions, TagImageOptions};
 use bollard::models::{BuildInfo, CreateImageInfo, ImageId};
 use bollard::Docker;
 use futures_util::stream::{StreamExt, TryStreamExt};
-use log::{debug, info, trace};
+use log::{debug, trace};
 use std::fmt;
 use std::fmt::Write;
 use std::path::PathBuf;
@@ -117,7 +117,7 @@ impl ImageManager {
                 ..
             } = create_image_info
             {
-                info!("{}: {}", id, status);
+                debug!("{}: {}", id, status);
             }
         }
 


### PR DESCRIPTION
The high level goal here is to make it so that `enclaver` gets updated versions of its dependencies when they're available.

I think that in the future we're going to want to do some work to constrain what versions `enclaver` will use based on some combination of lockfiles and semver matching against `enclaver`'s own version, but this should solve our most immediate problem, and begins laying the groundwork for those changes later.

This PR:

1. Modifies the GitHub workflow to:
  a. Only push `latest` when we tag a release
  b. Also push tags `v<major>.<minor>.<patch>`, `v<major>.<minor>` and `v<major>` when we tag a release
  c. Push a container image tagged with the git hash on every push to main, in case we want that for testing
2. Modifies `enclaver` to always pull the latest version of its dependencies _if_ those dependencies are not specified in the manifest. If they are specified in the manifest, we only pull them if a matching image is not found locally, to avoid inadvertently overwriting a locally-built image.

In the future we should be able to move to semver-constrained pulls fairly easily by changing the hardcoded `latest` tags to eg be templated in at build time based on git tags.