### PR TITLE
Adds /v1/attestation endpoint

### DIFF
--- a/enclaver/src/api.rs
+++ b/enclaver/src/api.rs
@@ -1,0 +1,141 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use http::{Method, Request, Response};
+use hyper::header;
+use hyper::{Body, StatusCode};
+use pkcs8::{DecodePublicKey, SubjectPublicKeyInfo};
+use serde::Deserialize;
+
+use crate::http_util::{self, HttpHandler};
+use crate::nsm::{AttestationParams, AttestationProvider};
+
+const MIME_APPLICATION_CBOR: &str = "application/cbor";
+
+pub struct ApiHandler {
+    attester: Box<dyn AttestationProvider + Send + Sync>,
+}
+
+impl ApiHandler {
+    pub fn new(attester: Box<dyn AttestationProvider + Send + Sync>) -> Self {
+        Self { attester }
+    }
+
+    async fn handle_attestation(
+        &self,
+        _head: &http::request::Parts,
+        body: &[u8],
+    ) -> Result<Response<Body>> {
+        let attestation_req: AttestationRequest = match serde_json::from_slice(body) {
+            Ok(req) => req,
+            Err(err) => return Ok(http_util::bad_request(err.to_string())),
+        };
+
+        let params = match attestation_req.into_params() {
+            Ok(params) => params,
+            Err(err) => return Ok(http_util::bad_request(err.to_string())),
+        };
+
+        let att_doc = self.attester.attestation(params)?;
+
+        Ok(Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, MIME_APPLICATION_CBOR)
+            .body(Body::from(att_doc))?)
+    }
+}
+
+#[async_trait]
+impl HttpHandler for ApiHandler {
+    async fn handle(&self, req: Request<Body>) -> Result<Response<Body>> {
+        let (head, body) = req.into_parts();
+        let body = hyper::body::to_bytes(body).await?;
+
+        match head.uri.path() {
+            "/v1/attestation" => match head.method {
+                Method::POST => self.handle_attestation(&head, &body).await,
+
+                _ => Ok(http_util::method_not_allowed()),
+            },
+            _ => Ok(http_util::not_found()),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct AttestationRequest {
+    nonce: Option<String>,
+    public_key: Option<String>,
+    user_data: Option<String>,
+}
+
+impl AttestationRequest {
+    fn into_params(self) -> Result<AttestationParams> {
+        Ok(AttestationParams {
+            nonce: self.nonce.map(|s| base64::decode(&s)).transpose()?,
+            public_key: self.public_key.map(|s| pem_decode(&s)).transpose()?,
+            user_data: self.user_data.map(|s| base64::decode(&s)).transpose()?,
+        })
+    }
+}
+
+struct DerPublicKey {
+    bytes: Vec<u8>,
+}
+
+impl<'a> TryFrom<SubjectPublicKeyInfo<'a>> for DerPublicKey {
+    type Error = pkcs8::spki::Error;
+
+    fn try_from(spki: SubjectPublicKeyInfo<'a>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            bytes: spki.subject_public_key.to_vec(),
+        })
+    }
+}
+
+impl DecodePublicKey for DerPublicKey {}
+
+impl DerPublicKey {
+    fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
+fn pem_decode(pem: &str) -> Result<Vec<u8>> {
+    let der = DerPublicKey::from_public_key_pem(pem)?;
+    Ok(der.into_bytes())
+}
+
+#[tokio::test]
+async fn test_attestation_handler() {
+    use crate::nsm::StaticAttestationProvider;
+    use assert2::assert;
+
+    let handler = ApiHandler::new(Box::new(StaticAttestationProvider::new(Vec::new())));
+
+    let body = json::object!(
+        public_key: "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyY9b3O0t0zDH3pcxYWW2\nTBjW302L3eL+S4C1rmW6OFIXa6U1ZrBtSvMvI3ievCVHq7AOof6xkbXXqobgbokc\n0514+7stOsq/CqnXGWhWwW+aCIj5FFi+gf4kXbXvUYKhUVFFJm5Rq71r5stt3B1p\njYC0Nm391GjR98gO9Sw8TGYx21Q7KuNFsfMa/dtYboFX38fQFw4eTHvSafErgZNO\nMUmzLPibM+1zXqHbXX1M5hyFMBJE28zNi+TmvopdMxsG/a2yTiM1j6Srw2Y5ZrE6\nO1Rr8MxrAepPbmybNOn0K0YIcf/KZurDuvOIuhsurxFgGTVQhsMZ0iNaXA0usFM+\npQIDAQAB\n-----END PUBLIC KEY-----".to_string(),
+    );
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/attestation")
+        .body(Body::from(json::stringify(body)))
+        .unwrap();
+
+    let resp = handler.handle(req).await.unwrap();
+    assert!(resp.status() == StatusCode::OK);
+
+    let body = json::object!(
+        nonce: base64::encode("the nonce"),
+        user_data: base64::encode("my data"),
+    );
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/attestation")
+        .body(Body::from(json::stringify(body)))
+        .unwrap();
+
+    let resp = handler.handle(req).await.unwrap();
+    assert!(resp.status() == StatusCode::OK);
+}

--- a/enclaver/src/bin/odyn/api.rs
+++ b/enclaver/src/bin/odyn/api.rs
@@ -1,0 +1,40 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use log::info;
+use tokio::task::JoinHandle;
+
+use crate::config::Configuration;
+use enclaver::api::ApiHandler;
+use enclaver::http_util::HttpServer;
+use enclaver::nsm::{Nsm, NsmAttestationProvider};
+
+pub struct ApiService {
+    task: Option<JoinHandle<()>>,
+}
+
+impl ApiService {
+    pub fn start(config: &Configuration, nsm: Arc<Nsm>) -> Result<Self> {
+        let task = if let Some(port) = config.api_port() {
+            info!("Starting API on port {port}");
+
+            let srv = HttpServer::bind(port)?;
+            let handler = ApiHandler::new(Box::new(NsmAttestationProvider::new(nsm)));
+
+            Some(tokio::task::spawn(async move {
+                _ = srv.serve(handler).await;
+            }))
+        } else {
+            None
+        };
+
+        Ok(Self { task })
+    }
+
+    pub async fn stop(self) {
+        if let Some(task) = self.task {
+            task.abort();
+            _ = task.await;
+        }
+    }
+}

--- a/enclaver/src/bin/odyn/config.rs
+++ b/enclaver/src/bin/odyn/config.rs
@@ -109,6 +109,10 @@ impl Configuration {
     pub fn kms_proxy_port(&self) -> Option<u16> {
         self.manifest.kms_proxy.as_ref().map(|kp| kp.listen_port)
     }
+
+    pub fn api_port(&self) -> Option<u16> {
+        self.manifest.api.as_ref().map(|a| a.listen_port)
+    }
 }
 
 impl KmsEndpointProvider for Configuration {

--- a/enclaver/src/http_util.rs
+++ b/enclaver/src/http_util.rs
@@ -1,0 +1,78 @@
+use std::convert::Infallible;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use hyper::{server::conn::AddrIncoming, Body, Request, Response, Server, StatusCode};
+
+#[async_trait]
+pub trait HttpHandler {
+    async fn handle(&self, req: Request<Body>) -> Result<Response<Body>>;
+}
+
+pub struct HttpServer {
+    incoming: AddrIncoming,
+}
+
+impl HttpServer {
+    pub fn bind(listen_port: u16) -> Result<Self> {
+        let listen_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, listen_port));
+        let incoming = AddrIncoming::bind(&listen_addr)?;
+        Ok(Self { incoming })
+    }
+
+    pub async fn serve<H: HttpHandler + Send + Sync + 'static>(self, handler: H) -> Result<()> {
+        let handler = Arc::new(handler);
+
+        // thanks https://www.fpcomplete.com/blog/ownership-puzzle-rust-async-hyper/
+        let make_svc = hyper::service::make_service_fn(move |_conn| {
+            // service_fn converts our function into a `Service`
+            let handler = handler.clone();
+            async {
+                Ok::<_, Infallible>(hyper::service::service_fn(move |req: Request<Body>| {
+                    let handler = handler.clone();
+                    async move {
+                        let resp = handler
+                            .handle(req)
+                            .await
+                            .unwrap_or_else(|err| internal_srv_err(err.to_string()));
+
+                        Result::<_, Infallible>::Ok(resp)
+                    }
+                }))
+            }
+        });
+
+        Server::builder(self.incoming).serve(make_svc).await?;
+        Ok(())
+    }
+}
+
+pub fn internal_srv_err(msg: String) -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::INTERNAL_SERVER_ERROR)
+        .body(Body::from(msg))
+        .unwrap()
+}
+
+pub fn bad_request(msg: String) -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::BAD_REQUEST)
+        .body(Body::from(msg))
+        .unwrap()
+}
+
+pub fn method_not_allowed() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::METHOD_NOT_ALLOWED)
+        .body(Body::empty())
+        .unwrap()
+}
+
+pub fn not_found() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(Body::empty())
+        .unwrap()
+}

--- a/enclaver/src/lib.rs
+++ b/enclaver/src/lib.rs
@@ -21,6 +21,9 @@ pub mod run;
 #[cfg(feature = "odyn")]
 pub mod nsm;
 
+#[cfg(feature = "odyn")]
+pub mod api;
+
 #[cfg(feature = "proxy")]
 pub mod proxy;
 
@@ -31,3 +34,5 @@ pub mod vsock;
 pub mod tls;
 
 pub mod utils;
+
+pub mod http_util;

--- a/enclaver/src/manifest.rs
+++ b/enclaver/src/manifest.rs
@@ -18,6 +18,7 @@ pub struct Manifest {
     pub egress: Option<Egress>,
     pub defaults: Option<Defaults>,
     pub kms_proxy: Option<KmsProxy>,
+    pub api: Option<Api>,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -62,6 +63,12 @@ pub struct Defaults {
 pub struct KmsProxy {
     pub listen_port: u16,
     pub endpoints: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Api {
+    pub listen_port: u16,
 }
 
 fn parse_manifest(buf: &[u8]) -> Result<Manifest> {

--- a/enclaver/src/nsm.rs
+++ b/enclaver/src/nsm.rs
@@ -1,7 +1,15 @@
+use std::sync::Arc;
+
 use anyhow::{anyhow, Result};
 use serde_bytes::ByteBuf;
 
 pub use aws_nitro_enclaves_nsm_api::api::{Request, Response};
+
+pub struct AttestationParams {
+    pub nonce: Option<Vec<u8>>,
+    pub user_data: Option<Vec<u8>>,
+    pub public_key: Option<Vec<u8>>,
+}
 
 pub struct Nsm {
     fd: i32,
@@ -22,11 +30,11 @@ impl Nsm {
         }
     }
 
-    pub fn attestation(&self, public_key: Option<Vec<u8>>) -> Result<Vec<u8>> {
+    pub fn attestation(&self, params: AttestationParams) -> Result<Vec<u8>> {
         let req = Request::Attestation {
-            nonce: None,
-            user_data: None,
-            public_key: public_key.map(ByteBuf::from),
+            nonce: params.nonce.map(ByteBuf::from),
+            user_data: params.user_data.map(ByteBuf::from),
+            public_key: params.public_key.map(ByteBuf::from),
         };
 
         match self.process_request(req)? {
@@ -46,5 +54,42 @@ impl Nsm {
 impl Drop for Nsm {
     fn drop(&mut self) {
         aws_nitro_enclaves_nsm_api::driver::nsm_exit(self.fd);
+    }
+}
+
+pub trait AttestationProvider {
+    fn attestation(&self, params: AttestationParams) -> Result<Vec<u8>>;
+}
+
+pub struct NsmAttestationProvider {
+    nsm: Arc<Nsm>,
+}
+
+impl NsmAttestationProvider {
+    pub fn new(nsm: Arc<Nsm>) -> Self {
+        Self { nsm }
+    }
+}
+
+impl AttestationProvider for NsmAttestationProvider {
+    fn attestation(&self, params: AttestationParams) -> Result<Vec<u8>> {
+        self.nsm.attestation(params)
+    }
+}
+
+// Always returns the same document, useful to tests
+pub struct StaticAttestationProvider {
+    doc: Vec<u8>,
+}
+
+impl StaticAttestationProvider {
+    pub fn new(doc: Vec<u8>) -> Self {
+        Self { doc }
+    }
+}
+
+impl AttestationProvider for StaticAttestationProvider {
+    fn attestation(&self, _params: AttestationParams) -> Result<Vec<u8>> {
+        Ok(self.doc.clone())
     }
 }

--- a/enclaver/src/run.rs
+++ b/enclaver/src/run.rs
@@ -186,6 +186,7 @@ impl Enclave {
 
         for item in ingress {
             let listen_port = item.listen_port;
+            info!("starting ingress proxy on port {listen_port}");
             let proxy = HostProxy::bind(listen_port).await?;
             self.tasks.push(tokio::task::spawn(async move {
                 proxy.serve(cid, listen_port.into()).await;


### PR DESCRIPTION
This introduces enclave internal API with its first endpoint -- attestation.
The api can be enabled in enclaver.yaml as follows:
```
api:
  listen_port: 7777
```

POST /v1/attestation expects a JSON payload of the form:
```
{
  nonce: <base64-encoded-string>,
  user_data: <base64-encoded-string>,
  public_key: <PEM-encoded-key>,
}
```
All fields are optional.
It returns the attestation document in CBOR format (NOT base64 encoded).