### PR TITLE
Make local_image_deps.sh work on ARM

### DIFF
--- a/build/dockerfiles/runtimebase-dev.dockerfile
+++ b/build/dockerfiles/runtimebase-dev.dockerfile
@@ -3,9 +3,21 @@ RUN touch /tmp/dummy
 
 ###############################
 
-FROM scratch
+FROM scratch AS build-amd64
+COPY --from=nitro_cli /lib64/ld-linux-x86-64.so.2 /lib64/
 
-COPY --from=nitro_cli /lib64/ld-linux-x86-64.so.2 /lib64/libssl.so.10 /lib64/libcrypto.so.10 /lib64/libgcc_s.so.1 /lib64/librt.so.1 /lib64/libpthread.so.0 /lib64/libm.so.6 /lib64/libdl.so.2 /lib64/libc.so.6 /lib64/libgssapi_krb5.so.2 /lib64/libkrb5.so.3 /lib64/libcom_err.so.2 /lib64/libk5crypto.so.3 /lib64/libz.so.1 /lib64/libkrb5support.so.0 /lib64/libkeyutils.so.1 /lib64/libresolv.so.2 /lib64/libselinux.so.1 /lib64/libpcre.so.1 /lib64/
+###############################
+
+FROM scratch AS build-arm64
+COPY --from=nitro_cli /lib/ld-linux-aarch64.so.1 /lib/
+
+###############################
+
+FROM build-${TARGETARCH} AS build
+
+ARG TARGETARCH
+
+COPY --from=nitro_cli /lib64/libssl.so.10 /lib64/libcrypto.so.10 /lib64/libgcc_s.so.1 /lib64/librt.so.1 /lib64/libpthread.so.0 /lib64/libm.so.6 /lib64/libdl.so.2 /lib64/libc.so.6 /lib64/libgssapi_krb5.so.2 /lib64/libkrb5.so.3 /lib64/libcom_err.so.2 /lib64/libk5crypto.so.3 /lib64/libz.so.1 /lib64/libkrb5support.so.0 /lib64/libkeyutils.so.1 /lib64/libresolv.so.2 /lib64/libselinux.so.1 /lib64/libpcre.so.1 /lib64/
 COPY --from=nitro_cli /usr/bin/nitro-cli /bin/nitro-cli
 
 COPY --from=nitro_cli /tmp/dummy /var/log/nitro_enclaves/

--- a/build/local_image_deps.sh
+++ b/build/local_image_deps.sh
@@ -2,8 +2,20 @@
 
 set -eu
 
-rust_target="x86_64-unknown-linux-musl"
-docker_target="amd64"
+local_arch=$(uname -m)
+case $local_arch in
+	x86_64)
+		rust_target="x86_64-unknown-linux-musl"
+		;;
+	aarch64)
+		rust_target="aarch64-unknown-linux-musl"
+		;;
+	*)
+		echo "Unsupported architecture: $local_arch"
+		exit 1
+		;;
+esac
+
 enclaver_dir="$(dirname $(dirname ${BASH_SOURCE[0]}))/enclaver"
 rust_target_dir="./target/${rust_target}/debug"
 


### PR DESCRIPTION
This PR:

1. Updates `runtimebase-dev.dockerfile` to mirror the multi-arch wizardry in `runtimebase.dockerfile` (perhaps at some point we should implement the same image-stripping stuff in our nitro-cli images so we can drop that from both)
2. Adds architecture detection to `build_local_deps.sh` so it automatically works on both x86_64 and aarch64