### PR TITLE
Clean up docs from feedback

### DIFF
--- a/docs/deploy-aws.md
+++ b/docs/deploy-aws.md
@@ -22,7 +22,7 @@ The example CloudFormation increases the allowed hops for the Instance Metadata 
 
 ## Run via Systemd Unit
 
-On the EC2 machine, add this systemd unit which runs the Enclaver tool in a container, then runs your specified enclave image:
+On the EC2 machine, add this systemd unit to `/etc/systemd/system/enclave.service` which runs the Enclaver tool in a container, then runs your specified enclave image:
 
 ```systemd
 [Unit]

--- a/docs/deploy-aws.md
+++ b/docs/deploy-aws.md
@@ -30,7 +30,7 @@ $ amazon-linux-extras install aws-nitro-enclaves-cli
 $ yum install aws-nitro-enclaves-cli-devel -y
 ```
 
-Then, give your user assess to the Nitro Enclaves and Docker groups:
+Then, give your user access to the Nitro Enclaves and Docker groups:
 
 ```
 $ usermod -aG ne ec2-user

--- a/docs/deploy-aws.md
+++ b/docs/deploy-aws.md
@@ -48,6 +48,8 @@ $ systemctl start docker && sudo systemctl enable docker
 
 Starting the Nitro allocator at boot is important because hugepages needs to find contiguous sections of RAM, which is easy when nothing is using your RAM yet.
 
+Unless you started your instance with a modified `HttpPutResponseHopLimit` from 1 to 2, you will need to run your container with host networking (`--net=host`) instead of the example shown below in order to connect to the instance metadata service.
+
 </details>
 
 ## Run via Systemd Unit

--- a/docs/deploy-aws.md
+++ b/docs/deploy-aws.md
@@ -20,6 +20,36 @@ Due to Amazon restrictions, each EC2 machine can only run a single enclave at a 
 
 The example CloudFormation increases the allowed hops for the Instance Metadata Service v2 from 1 to 2 to account for the `docker0` bridge. Reflect this change in any customized CloudFormation that you might use.
 
+<details>
+  <summary>View instructions to configure your machine manually</summary>
+
+First, install the Nitro Enclave packages:
+
+```
+$ amazon-linux-extras install aws-nitro-enclaves-cli
+$ yum install aws-nitro-enclaves-cli-devel -y
+```
+
+Then, give your user assess to the Nitro Enclaves and Docker groups:
+
+```
+$ usermod -aG ne ec2-user
+$ usermod -aG docker ec2-user
+```
+
+Last, configure the resources to dedicate to your enclaves:
+
+```
+$ sed -i 's/cpu_count: 2/cpu_count: 1/g' /etc/nitro_enclaves/allocator.yaml
+$ sed -i 's/memory_mib: 512/memory_mib: 3072/g' /etc/nitro_enclaves/allocator.yaml
+$ systemctl start nitro-enclaves-allocator.service && sudo systemctl enable nitro-enclaves-allocator.service
+$ systemctl start docker && sudo systemctl enable docker
+```
+
+Starting the Nitro allocator at boot is important because hugepages needs to find contiguous sections of RAM, which is easy when nothing is using your RAM yet.
+
+</details>
+
 ## Run via Systemd Unit
 
 On the EC2 machine, add this systemd unit to `/etc/systemd/system/enclave.service` which runs the Enclaver tool in a container, then runs your specified enclave image:

--- a/docs/guide-app.md
+++ b/docs/guide-app.md
@@ -159,6 +159,8 @@ $ ssh ec2-user@<ip address>
 
 After the image is fetched, it is broken apart into [the outside][outside] and [inside components][inside]. The outer components are started first, then the enclave, with the inner components inside, is started.
 
+<div style="background: #F5BF4F; padding: 5px 10px;">Note: you must use the container image shipped by EdgeBit for the demo to work correctly. The build above is shown for educational purposes but your build will cause the PCR measurements to differ from the key access policy.</div>
+
 We will start it manually using Docker, but you can also set up a [systemd unit][unit].
 
 ```sh


### PR DESCRIPTION
1. mention `/etc/systemd/system` as the location for units
2. include manual instructions for configuring a default Amazon Linux EC2 machine
3. show warning to use our automated container builds in order to complete the No-Fly-List demo successfully

cc: @stskeeps