### PR TITLE
Use MSRV for Clippy check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,10 +8,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2022-10-24
-          components: clippy
+
+      # Install the MSRV toolchain and clippy
+      - run: sed -n 's/^rust-version = "\(.*\)"$/RUSTUP_TOOLCHAIN=\1/p' enclaver/Cargo.toml >> $GITHUB_ENV
+      - run: rustup toolchain install $RUSTUP_TOOLCHAIN
+      - run: rustup component add clippy
 
       # Check with --all-features (ie a Linux build)
       - uses: actions-rs/clippy@master

--- a/enclaver/Cargo.toml
+++ b/enclaver/Cargo.toml
@@ -2,6 +2,7 @@
 name = "enclaver"
 version = "0.2.0"
 edition = "2021"
+rust-version = "1.67"
 
 [[bin]]
 name = "odyn"

--- a/enclaver/src/api.rs
+++ b/enclaver/src/api.rs
@@ -71,9 +71,9 @@ struct AttestationRequest {
 impl AttestationRequest {
     fn into_params(self) -> Result<AttestationParams> {
         Ok(AttestationParams {
-            nonce: self.nonce.map(|s| base64::decode(&s)).transpose()?,
+            nonce: self.nonce.map(base64::decode).transpose()?,
             public_key: self.public_key.map(|s| pem_decode(&s)).transpose()?,
-            user_data: self.user_data.map(|s| base64::decode(&s)).transpose()?,
+            user_data: self.user_data.map(base64::decode).transpose()?,
         })
     }
 }

--- a/enclaver/src/bin/enclaver/main.rs
+++ b/enclaver/src/bin/enclaver/main.rs
@@ -81,7 +81,7 @@ async fn run(args: Cli) -> Result<()> {
             println!("EIF Info:");
 
             stdout().write_all(&eif_info_bytes).await?;
-            println!("");
+            println!();
 
             Ok(())
         }
@@ -100,7 +100,7 @@ async fn run(args: Cli) -> Result<()> {
             println!("EIF Info:");
 
             stdout().write_all(&eif_info_bytes).await?;
-            println!("");
+            println!();
 
             Ok(())
         }

--- a/enclaver/src/bin/odyn/config.rs
+++ b/enclaver/src/bin/odyn/config.rs
@@ -50,7 +50,7 @@ impl Configuration {
 
         Ok(Self {
             config_dir: config_dir.as_ref().to_path_buf(),
-            manifest: manifest,
+            manifest,
             listener_configs,
         })
     }
@@ -121,12 +121,11 @@ impl KmsEndpointProvider for Configuration {
             .manifest
             .kms_proxy
             .as_ref()
-            .map(|kp| {
+            .and_then(|kp| {
                 kp.endpoints
                     .as_ref()
-                    .map(|eps| eps.get(region).map(|ep| ep.clone()))
+                    .map(|eps| eps.get(region).cloned())
             })
-            .flatten()
             .flatten();
 
         ep.unwrap_or_else(|| format!("kms.{region}.amazonaws.com"))

--- a/enclaver/src/bin/odyn/console.rs
+++ b/enclaver/src/bin/odyn/console.rs
@@ -19,7 +19,7 @@ struct LogCursor {
 
 impl LogCursor {
     fn new() -> Self {
-        return Self { pos: 0usize };
+        Self { pos: 0usize }
     }
 }
 
@@ -130,7 +130,7 @@ fn new_app_log() -> Result<(LogWriter, LogServicer, LogReader)> {
         log: log.clone(),
     };
 
-    let lr = LogReader { log: log };
+    let lr = LogReader { log };
 
     Ok((lw, ls, lr))
 }

--- a/enclaver/src/bin/odyn/enclave.rs
+++ b/enclaver/src/bin/odyn/enclave.rs
@@ -36,6 +36,6 @@ async fn lo_up() -> Result<()> {
 
 fn seed_rng(nsm: &Nsm) -> Result<()> {
     let seed = nsm.get_random()?;
-    std::fs::write(&DEV_RANDOM, seed)?;
+    std::fs::write(DEV_RANDOM, seed)?;
     Ok(())
 }

--- a/enclaver/src/build.rs
+++ b/enclaver/src/build.rs
@@ -350,7 +350,7 @@ impl EnclaveArtifactBuilder {
         }
 
         // If we make it this far, do a little bit of cleanup
-        let _ = self
+        self
             .docker
             .remove_container(&build_container_id, None)
             .await?;

--- a/enclaver/src/nsm.rs
+++ b/enclaver/src/nsm.rs
@@ -46,7 +46,7 @@ impl Nsm {
     fn process_request(&self, req: Request) -> Result<Response> {
         match aws_nitro_enclaves_nsm_api::driver::nsm_process_request(self.fd, req) {
             Response::Error(err) => Err(anyhow!("nsm request failed with: {:?}", err)),
-            resp @ _ => Ok(resp),
+            resp => Ok(resp),
         }
     }
 }

--- a/enclaver/src/policy/domain_filter.rs
+++ b/enclaver/src/policy/domain_filter.rs
@@ -148,13 +148,13 @@ mod tests {
         for tc in &cases {
             let pat = Pattern::new(tc.pattern);
 
-            let pos = tc.positives.iter().map(|d| Domain::new(*d));
+            let pos = tc.positives.iter().map(|d| Domain::new(d));
 
             for d in pos {
                 assert!(pat.matches(&d));
             }
 
-            let neg = tc.negatives.iter().map(|d| Domain::new(*d));
+            let neg = tc.negatives.iter().map(|d| Domain::new(d));
 
             for d in neg {
                 assert!(!pat.matches(&d));

--- a/enclaver/src/proxy/egress_http.rs
+++ b/enclaver/src/proxy/egress_http.rs
@@ -61,8 +61,8 @@ struct ConnectRequest {
 impl ConnectRequest {
     fn new(host: String, port: u16) -> Self {
         Self {
-            host: host,
-            port: port,
+            host,
+            port,
         }
     }
 }
@@ -456,7 +456,7 @@ mod tests {
             _ = pretty_env_logger::try_init();
 
             return Self {
-                base_port: base_port,
+                base_port,
                 enclave_proxy_task: start_enclave_proxy(base_port, base_port as u32).await,
                 host_proxy_task: start_host_proxy(base_port as u32),
                 echo_task: start_echo_server(base_port + 1, use_tls),
@@ -519,7 +519,7 @@ mod tests {
 
         // Connection failure
         let resp2 = client
-            .post(format!("http://adfadfadfadfadsfa.local/echo"))
+            .post("http://adfadfadfadfadsfa.local/echo".to_string())
             .body(expected.clone())
             .send()
             .await
@@ -558,7 +558,7 @@ mod tests {
 
         // Connection failure
         let resp_result = client
-            .post(format!("https://adfadfadfadfadsfa.local/echo"))
+            .post("https://adfadfadfadfadsfa.local/echo".to_string())
             .body(expected.clone())
             .send()
             .await;

--- a/enclaver/src/proxy/ingress.rs
+++ b/enclaver/src/proxy/ingress.rs
@@ -90,7 +90,7 @@ impl HostProxy {
         while let Ok((sock, _)) = self.listener.accept().await {
             // TODO: don't use detached tasks
             tokio::task::spawn(async move {
-                _ = HostProxy::service_conn(sock, target_cid, target_port).await;
+                HostProxy::service_conn(sock, target_cid, target_port).await;;
             });
         }
     }

--- a/enclaver/src/proxy/pkcs7.rs
+++ b/enclaver/src/proxy/pkcs7.rs
@@ -34,7 +34,7 @@ pub struct ContentInfo<'a> {
 
 impl<'a> ContentInfo<'a> {
     pub fn parse_ber(ber: &'a [u8]) -> Result<Self> {
-        let (rem, ci) = Self::from_ber(&ber)?;
+        let (rem, ci) = Self::from_ber(ber)?;
 
         if !rem.is_empty() {
             return Err(anyhow!(
@@ -62,10 +62,10 @@ impl<'a> ContentInfo<'a> {
 
     pub fn decrypt_content(&self, priv_key: &RsaPrivateKey) -> Result<Vec<u8>> {
         let datakey = self.decrypt_key(priv_key)?;
-        Ok(self
+        self
             .content
             .encrypted_content_info
-            .decrypt_content(&datakey)?)
+            .decrypt_content(&datakey)
     }
 
     fn decrypt_key(&self, priv_key: &RsaPrivateKey) -> Result<Vec<u8>> {

--- a/enclaver/src/tls.rs
+++ b/enclaver/src/tls.rs
@@ -17,7 +17,7 @@ fn load_keys(path: &Path) -> Result<Vec<PrivateKey>> {
     let mut key_bufs = rustls_pemfile::pkcs8_private_keys(&mut BufReader::new(File::open(path)?))
         .map_err(|_| anyhow!("invalid key"))?;
 
-    let keys: Vec<PrivateKey> = key_bufs.drain(..).map(|buf| PrivateKey(buf)).collect();
+    let keys: Vec<PrivateKey> = key_bufs.drain(..).map(PrivateKey).collect();
 
     info!("Loaded {} TLS keys", keys.len());
 


### PR DESCRIPTION
8439319 bumped the Rust version used in the release process to follow
the stable channel, but left CI pinned to a specific nightly
release. This updates the Rust version, but rather than updating the
CI job to also follow the stable channel, this uses the MSRV specified
in the manifest. This will allow us to control when the Clippy lints
change rather than them changing whenever there is a new stable
release.