### PR TITLE
Make Clippy fail on warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+    checks: write
+
 env:
   RUSTFLAGS: "-Dwarnings"
 
@@ -18,14 +21,16 @@ jobs:
       - run: rustup component add clippy
 
       # Check with --all-features (ie a Linux build)
-      - uses: actions-rs/clippy@master
+      - uses: actions-rs/clippy-check@v1.0.7
         with:
           args: --all-features --manifest-path enclaver/Cargo.toml
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       # Check with only default features (ie a Mac build)
-      - uses: actions-rs/clippy@master
+      - uses: actions-rs/clippy-check@v1.0.7
         with:
           args: --manifest-path enclaver/Cargo.toml
+          token: ${{ secrets.GITHUB_TOKEN }}
 
 
   ## TODO: Add test job here?

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+env:
+  RUSTFLAGS: "-Dwarnings"
+
 jobs:
   clippy-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
-  clippy-check:
+  clippy:
     runs-on: ubuntu-latest
 
     steps:

--- a/enclaver/Cargo.lock
+++ b/enclaver/Cargo.lock
@@ -772,6 +772,7 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-proxy",
+ "ignore-result",
  "ipnetwork",
  "json",
  "lazy_static",
@@ -1231,6 +1232,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "ignore-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "665ff4dce8edd10d490641ccb78949832f1ddbff02c584fb1f85ab888fe0e50c"
 
 [[package]]
 name = "indexmap"

--- a/enclaver/Cargo.toml
+++ b/enclaver/Cargo.toml
@@ -68,6 +68,7 @@ asn1-rs = "0.5.2"
 cbc = { version = "0.1", features = [ "std", "block-padding" ] }
 aes = "0.8"
 sha2 = "0.10"
+ignore-result = "0.2.0"
 
 
 [dev-dependencies]

--- a/enclaver/src/bin/enclaver/main.rs
+++ b/enclaver/src/bin/enclaver/main.rs
@@ -100,7 +100,7 @@ async fn run(args: Cli) -> Result<()> {
             println!("EIF Info:");
 
             stdout().write_all(&eif_info_bytes).await?;
-            println!();
+            println!();;
 
             Ok(())
         }

--- a/enclaver/src/bin/odyn/console.rs
+++ b/enclaver/src/bin/odyn/console.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use circbuf::CircBuf;
 use futures::Stream;
+use ignore_result::Ignore;
 use std::os::unix::io::AsRawFd;
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -47,7 +48,7 @@ impl ByteLog {
         let avail = self.buffer.avail();
         if avail < data.len() {
             trim_cnt = data.len() - avail;
-            self.buffer.advance_read(trim_cnt);
+            self.buffer.advance_read(trim_cnt).ignore();
             self.head += trim_cnt;
         }
         assert!(self.buffer.avail() >= data.len());

--- a/enclaver/src/bin/odyn/main.rs
+++ b/enclaver/src/bin/odyn/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::new_without_default)]
+
 pub mod api;
 pub mod config;
 pub mod console;

--- a/enclaver/src/lib.rs
+++ b/enclaver/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::new_without_default)]
+
 extern crate core;
 
 pub mod build;

--- a/enclaver/src/nitro_cli.rs
+++ b/enclaver/src/nitro_cli.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 use log::debug;
 use serde::{Deserialize, Serialize};
 use std::ffi::OsString;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use tokio::process::{ChildStdout, Command};
 
@@ -68,7 +68,7 @@ impl NitroCLI {
         }
     }
 
-    pub async fn describe_eif(&self, eif_path: &PathBuf) -> Result<EIFInfo> {
+    pub async fn describe_eif(&self, eif_path: &Path) -> Result<EIFInfo> {
         self.run_and_deserialize_output(DescribeEifArgs {
             eif_path: eif_path.to_path_buf(),
         })

--- a/enclaver/src/proxy/ingress.rs
+++ b/enclaver/src/proxy/ingress.rs
@@ -90,7 +90,7 @@ impl HostProxy {
         while let Ok((sock, _)) = self.listener.accept().await {
             // TODO: don't use detached tasks
             tokio::task::spawn(async move {
-                HostProxy::service_conn(sock, target_cid, target_port).await;;
+                HostProxy::service_conn(sock, target_cid, target_port).await;
             });
         }
     }

--- a/enclaver/src/proxy/kms.rs
+++ b/enclaver/src/proxy/kms.rs
@@ -19,7 +19,7 @@ use crate::http_util::HttpHandler;
 use crate::keypair::KeyPair;
 use crate::nsm::{AttestationParams, AttestationProvider};
 
-const X_AMZ_TARGET: HeaderName = HeaderName::from_static("x-amz-target");
+static X_AMZ_TARGET: HeaderName = HeaderName::from_static("x-amz-target");
 
 static X_AMZ_JSON: HeaderValue = HeaderValue::from_static("application/x-amz-json-1.1");
 
@@ -107,7 +107,7 @@ impl KmsRequestIncoming {
     }
 
     fn target(&self) -> Option<&HeaderValue> {
-        self.head.headers.get(X_AMZ_TARGET)
+        self.head.headers.get(&X_AMZ_TARGET)
     }
 
     fn content_type(&self) -> &HeaderValue {
@@ -131,7 +131,7 @@ impl KmsRequestIncoming {
         false
     }
 
-    fn credential_scope<'a>(&'a self) -> Result<CredentialScope> {
+    fn credential_scope(&self) -> Result<CredentialScope> {
         CredentialScope::from_request(&self.head)
     }
 }
@@ -153,7 +153,7 @@ impl KmsRequestOutgoing {
         let inner = Request::builder()
             .method(Method::POST)
             .uri(uri)
-            .header(X_AMZ_TARGET, action)
+            .header(&X_AMZ_TARGET, action)
             .header(hyper::header::CONTENT_TYPE, &X_AMZ_JSON)
             .body(body_bytes)?;
 
@@ -172,7 +172,7 @@ impl KmsRequestOutgoing {
         let inner = Request::builder()
             .method(req_in.method())
             .uri(uri)
-            .header(X_AMZ_TARGET, action)
+            .header(&X_AMZ_TARGET, action)
             .header(hyper::header::CONTENT_TYPE, req_in.content_type())
             .body(req_in.body)?;
 


### PR DESCRIPTION
Also allow clippy::new_without_default. This lint suggests adding a
`Default` implementation for a number of types, but this is more
applicable for a library than an executable.