### PR TITLE
Run CI against code in pull request

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request_target]
+on: [push, pull_request]
 
 jobs:
   clippy-check:


### PR DESCRIPTION
From the [documentation for `pull_request_target`][1], "This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does." So CI was running against what had already been merged into main, rather than what was in the pull request.

[1]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target