### PR TITLE
Use sparse registry protocol when fetching dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+env:
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: "sparse"
+
 jobs:
   clippy-check:
     runs-on: ubuntu-latest

--- a/enclaver/Cargo.toml
+++ b/enclaver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "enclaver"
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.68"
 
 [[bin]]
 name = "odyn"


### PR DESCRIPTION
This cuts roughly two minutes (60%) off the time it takes to run the
CI workflow. The sparse registry protocol was first supported in Rust
1.68, so bump the MSRV to match. This slowdown was introduced in
04b0123, which changed the Rust version from stable (1.71 at the
time) to 1.67. The sparse registry protocol was enabled by default in
1.70.