### PR TITLE
Use correct info string in fenced code blocks

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ These use-cases directly map to `enclaver` commands. Refer to the [full list of 
 
 In this example, our manifest file contains the source app container `edgebit-containers/containers/no-fly-list` (see [sample Python app][app-guide]) and the resulting enclave image is saved as `no-fly-list:enclave-latest`:
 
-```sh
+```console
 $ enclaver build --file enclaver.yaml
  INFO  enclaver::images > latest: Pulling from edgebit-containers/containers/no-fly-list
  INFO  enclaver::images > latest: Pulling from edgebit-containers/containers/odyn
@@ -66,7 +66,7 @@ Images built by Enclaver can be run using Docker, or another container runtime. 
 
 All of this happens transparently to you, so the experience you get is very close to running the app outside of an enclave:
 
-```sh
+```console
 $ enclaver run no-fly-list:enclave-latest -p 8001:8001
  INFO  enclaver::run   > starting egress proxy on vsock port 17002
  INFO  enclaver::vsock > Listening on vsock port 17002
@@ -122,7 +122,7 @@ To minimize the attack surface of enclave applications, it is not possible to pa
 <details>
     <summary>TODO: Implement enclaver trust command. See [issue #38](https://github.com/edgebitio/enclaver/issues/38).</summary>
 
-```sh
+```console
 $ enclaver trust registry.example.com/my-app:v1.0
 {
   "Measurements": {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,7 +17,7 @@ can be distributed and run using existing container registries, Docker, Kubernet
 
 ## Build
 
-```sh
+```console
 $ enclaver build [options]
 ```
 
@@ -31,7 +31,7 @@ Builds an OCI container image in [Enclaver image format][format] containing the 
 
 ## Run
 
-```sh
+```console
 $ enclaver run [OPTIONS] [image]
 ```
 
@@ -40,9 +40,7 @@ Run a packaged Enclaver container image without typing long Docker commands.
 This command is a convenience utility that runs a pre-existing Enclaver image in the local Docker
 Daemon. It is equivalent to running the image with Docker, and passing:
 
-```sh
     --device=/dev/nitro_enclaves:/dev/nitro_enclaves:rwm
-```
 
 Requires a local Docker Daemon to be running, and that this computer is an AWS instance configured
 to support Nitro Enclaves.

--- a/docs/deploy-aws.md
+++ b/docs/deploy-aws.md
@@ -25,21 +25,21 @@ The example CloudFormation increases the allowed hops for the Instance Metadata 
 
 First, install the Nitro Enclave packages:
 
-```
+```console
 $ amazon-linux-extras install aws-nitro-enclaves-cli
 $ yum install aws-nitro-enclaves-cli-devel -y
 ```
 
 Then, give your user access to the Nitro Enclaves and Docker groups:
 
-```
+```console
 $ usermod -aG ne ec2-user
 $ usermod -aG docker ec2-user
 ```
 
 Last, configure the resources to dedicate to your enclaves:
 
-```
+```console
 $ sed -i 's/cpu_count: 2/cpu_count: 1/g' /etc/nitro_enclaves/allocator.yaml
 $ sed -i 's/memory_mib: 512/memory_mib: 3072/g' /etc/nitro_enclaves/allocator.yaml
 $ systemctl start nitro-enclaves-allocator.service && sudo systemctl enable nitro-enclaves-allocator.service
@@ -83,7 +83,7 @@ WantedBy=multi-user.target
 
 Be sure to swap out `registry.edgebit.io/no-fly-list:enclave-latest` for your image location. Afterwards, start the unit and enable the unit so it starts again after a reboot:
 
-```sh
+```console
 $ systemctl start enclave.service && systemctl enable enclave.service
 ```
 
@@ -91,7 +91,7 @@ $ systemctl start enclave.service && systemctl enable enclave.service
 
 The example app answers web requests on port 8001 of the EC2 machine:
 
-```sh
+```console
 $ curl localhost:8001
 "https://edgebit.io/enclaver/docs/0.x/guide-app/"
 ```

--- a/docs/deploy-aws.md
+++ b/docs/deploy-aws.md
@@ -84,7 +84,7 @@ WantedBy=multi-user.target
 Be sure to swap out `registry.edgebit.io/no-fly-list:enclave-latest` for your image location. Afterwards, start the unit and enable the unit so it starts again after a reboot:
 
 ```console
-$ systemctl start enclave.service && systemctl enable enclave.service
+$ systemctl enable --now enclave.service
 ```
 
 ## Testing the Enclave

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -95,7 +95,7 @@ Due to Amazon restrictions, each EC2 machine can only run a single enclave at a 
 
 The CloudFormation will label your Nodes with `edgebit.io/enclave=nitro` so that your Deployment can target the qualified Nodes.
 
-```sh
+```console
 $ kubectl get nodes --selector=edgebit.io/enclave=nitro
 NAME                            STATUS   ROLES    AGE     VERSION
 ip-172-31-37-102.ec2.internal   Ready    <none>   5m      v1.23.9-eks-ba74326
@@ -110,19 +110,19 @@ You may also Taint your Nodes so other workloads don't land on it, but in most c
 
 Submit the sample enclave application to the cluster ([download here][k8s-deployment]):
 
-```sh
+```console
 $ kubectl create -f example-enclave.yaml
 ```
 
 The example app answers web requests on port 8001. You can make a Service and Load Balancer to address all of the Pods, or for a simple test, port-forward to the Pod:
 
-```sh
+```console
 $ kubectl port-forward <podname> 8001:8001
 ```
 
 Then send a request to the forward port, which will be answered from within the enclave:
 
-```sh
+```console
 $ curl localhost:8001
 "https://edgebit.io/enclaver/docs/0.x/guide-app/"
 ```
@@ -136,7 +136,7 @@ Jump over to the [simple Python app][app] guide (the URL printed above) that exp
 
 If your pods are pending, check that hugepages is enabled on your Nodes. Here's what the status block of a pending Node looks like:
 
-```sh
+```console
 $ kubectl get pods/example-enclave-5fbddb6cc8-nspgw -o yaml
 ...
 status:
@@ -153,7 +153,7 @@ status:
 
 Check that Kubernetes is reading the available hugepages by looking at one of your Nitro Enclave Nodes. Here you can see that `hugepages-1Gi` has capacity for `3Gi`. If your Node is not configured correctly, you might see a `0` for both hugepages entries.
 
-```sh
+```console
 $ kubectl get nodes/ip-172-31-37-102.ec2.internal -o yaml
 ...
   allocatable:

--- a/docs/guide-app.md
+++ b/docs/guide-app.md
@@ -27,7 +27,7 @@ Here's an example of an attestation:
 
 TODO: Implement trust command. See [issue #38](https://github.com/edgebitio/enclaver/issues/38).
 
-```sh
+```console
 $ enclaver trust registry.edgebit.io/no-fly-list:enclave-latest
 TODO: add real attestation
 ```
@@ -129,7 +129,7 @@ It's pretty straightforward. The `sources.app` parameter specifies the source co
 
 We're passing in our manifest file from above to the build:
 
-```sh
+```console
 $ enclaver build --file enclaver.yaml
  INFO  enclaver::images > latest: Pulling from edgebit-containers/containers/no-fly-list
  INFO  enclaver::images > latest: Pulling from edgebit-containers/containers/odyn
@@ -153,7 +153,7 @@ EIF Info: EIFInfo {
 
 `enclaver run` executes on an EC2 machine to fetch, unpack and run your enclave image. First, SSH to your EC2 machine:
 
-```sh
+```console
 $ ssh ec2-user@<ip address>
 ```
 
@@ -163,7 +163,7 @@ After the image is fetched, it is broken apart into [the outside][outside] and [
 
 We will start it manually using Docker, but you can also set up a [systemd unit][unit].
 
-```sh
+```console
 $ docker run \
     --rm \
     --detach \
@@ -175,7 +175,7 @@ $ docker run \
 
 Check to see that the enclave was run successfully:
 
-```sh
+```console
 $ docker logs enclave
  INFO  enclaver::run   > starting egress proxy on vsock port 17002
  INFO  enclaver::vsock > Listening on vsock port 17002
@@ -212,7 +212,7 @@ Now the fun part. Let's see who can fly and who can't. Remember, a key part of t
 
 We know that members of Sesame Street might not be allowed to fly. Test it out for yourself from the EC2 machine:
 
-```sh
+```console
 $ curl localhost:8001/enclave/passenger?name=foo
 foo is cleared to fly. Enjoy your flight!
 ```

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -11,7 +11,7 @@ Enclaver relies on a manifest file to understand how to transform your container
 
 The file is YAML formatted and passed to Enclaver via the `-f` flag. By default, Enclaver looks for `enclaver.yaml` in the current directory.
 
-```sh
+```console
 $ enclaver build -f enclaver.yaml
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,7 +11,7 @@ weight: 30
 
 By default, minimal logs are returned from the enclave, as a security precaution. The `--debug-mode` flag will enable debug mode on the enclave, and translate `/dev/console` output to log lines.
 
-```sh
+```console
 $ enclaver run --debug-mode
 ```
 
@@ -23,7 +23,7 @@ Enclaves running on x86 instances must have whole numbers of vCPUs, in multiples
 
 The minimum core count is 2. The following error appears to be about memory, but is actually due to 1 core being specified instead of 2.
 
-```sh
+```console
 $ enclaver run ...
 error: nitro-cli failed: Start allocating memory...
 ```


### PR DESCRIPTION
`sh` was being used where `console` was more appropriate; the former being for shell scripts and the latter for console interaction. I also cleaned up a set of commands in the Vault documentation to make copying-and-pasting easier and fixed the formatting of some IAM policies.