### PR TITLE
Add verbosity flag

### DIFF
--- a/enclaver/src/bin/enclaver-run/main.rs
+++ b/enclaver/src/bin/enclaver-run/main.rs
@@ -37,6 +37,9 @@ struct Cli {
 
     #[clap(subcommand)]
     sub_command: Option<SubCommand>,
+
+    #[clap(long = "verbose", short = 'v', parse(from_occurrences))]
+    verbosity: u8,
 }
 
 #[derive(Debug, Subcommand)]
@@ -121,15 +124,14 @@ async fn describe_eif() -> Result<CLISuccess> {
 
 #[tokio::main]
 async fn main() -> Result<CLISuccess> {
-    enclaver::utils::init_logging();
+    let args = Cli::parse();
+    enclaver::utils::init_logging(args.verbosity);
 
     #[cfg(feature = "tracing")]
     console_subscriber::ConsoleLayer::builder()
         .with_default_env()
         .server_addr(([0, 0, 0, 0], 51001))
         .init();
-
-    let args = Cli::parse();
 
     match args.sub_command {
         None => run(args).await,

--- a/enclaver/src/bin/enclaver/main.rs
+++ b/enclaver/src/bin/enclaver/main.rs
@@ -28,8 +28,8 @@ enum Commands {
         /// Only build the EIF file, do not package it into a self-executing image.
         eif_file: Option<String>,
 
-        #[clap(long = "--pull")]
-        /// Pull any Docker images this depends on bef
+        #[clap(long = "pull")]
+        /// Pull every container image to ensure the latest version
         force_pull: bool,
     },
 

--- a/enclaver/src/bin/enclaver/main.rs
+++ b/enclaver/src/bin/enclaver/main.rs
@@ -13,6 +13,9 @@ use tokio::io::{stdout, AsyncWriteExt};
 struct Cli {
     #[clap(subcommand)]
     subcommand: Commands,
+
+    #[clap(long = "verbose", short = 'v', parse(from_occurrences))]
+    verbosity: u8,
 }
 
 #[derive(Debug, Subcommand)]
@@ -156,9 +159,9 @@ async fn run(args: Cli) -> Result<()> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    enclaver::utils::init_logging();
-
     let args = Cli::parse();
+    enclaver::utils::init_logging(args.verbosity);
+
 
     #[cfg(feature = "tracing")]
     console_subscriber::ConsoleLayer::builder()

--- a/enclaver/src/bin/odyn/main.rs
+++ b/enclaver/src/bin/odyn/main.rs
@@ -38,6 +38,9 @@ struct CliArgs {
 
     #[clap(required = true)]
     entrypoint: Vec<OsString>,
+
+    #[clap(long = "verbose", short = 'v', parse(from_occurrences))]
+    verbosity: u8,
 }
 
 async fn launch(args: &CliArgs) -> Result<launcher::ExitStatus> {
@@ -98,8 +101,8 @@ async fn run(args: &CliArgs) -> Result<()> {
 
 #[tokio::main]
 async fn main() {
-    enclaver::utils::init_logging();
     let args = CliArgs::parse();
+    enclaver::utils::init_logging(args.verbosity);
 
     #[cfg(feature = "tracing")]
     console_subscriber::ConsoleLayer::builder()


### PR DESCRIPTION
This makes it easier to control the amount of logging since the flag
is more discoverable than a language-specific environment variable and
the logging filters already take into account the noisy dependencies.
The relative logging levels were chosen arbitrarily, based on what
felt reasonable when running the enclaver binary. These module filters
apply to all of the binaries, even though they aren't necessarily
applicable.