### PR TITLE
Wait for ingress traffic before shutting down

### DIFF
--- a/enclaver/src/bin/odyn/egress.rs
+++ b/enclaver/src/bin/odyn/egress.rs
@@ -16,7 +16,7 @@ pub struct EgressService {
 impl EgressService {
     pub async fn start(config: &Configuration) -> Result<Self> {
         let task = if let Some(proxy_uri) = config.egress_proxy_uri() {
-            info!("Startng egress");
+            info!("Starting egress");
 
             let policy = Arc::new(EgressPolicy::new(config.manifest.egress.as_ref().unwrap()));
 

--- a/enclaver/src/bin/odyn/ingress.rs
+++ b/enclaver/src/bin/odyn/ingress.rs
@@ -16,12 +16,12 @@ impl IngressService {
         for (port, cfg) in &config.listener_configs {
             match cfg {
                 ListenerConfig::TCP => {
-                    info!("Startng TCP ingress on port {}", *port);
+                    info!("Starting TCP ingress on port {}", *port);
                     let proxy = EnclaveProxy::bind(*port)?;
                     tasks.push(tokio::spawn(proxy.serve()));
                 }
                 ListenerConfig::TLS(tls_cfg) => {
-                    info!("Startng TLS ingress on port {}", *port);
+                    info!("Starting TLS ingress on port {}", *port);
                     let proxy = EnclaveProxy::bind_tls(*port, tls_cfg.clone())?;
                     tasks.push(tokio::spawn(proxy.serve()));
                 }

--- a/enclaver/src/bin/odyn/ingress.rs
+++ b/enclaver/src/bin/odyn/ingress.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
+use ignore_result::Ignore;
 use log::info;
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
 use crate::config::{Configuration, ListenerConfig};
@@ -7,37 +9,40 @@ use enclaver::proxy::ingress::EnclaveProxy;
 
 pub struct IngressService {
     proxies: Vec<JoinHandle<()>>,
+    shutdown: watch::Sender<()>,
 }
 
 impl IngressService {
     pub fn start(config: &Configuration) -> Result<Self> {
         let mut tasks = Vec::new();
 
+        let (tx, rx) = tokio::sync::watch::channel(());
         for (port, cfg) in &config.listener_configs {
             match cfg {
                 ListenerConfig::TCP => {
                     info!("Starting TCP ingress on port {}", *port);
                     let proxy = EnclaveProxy::bind(*port)?;
-                    tasks.push(tokio::spawn(proxy.serve()));
+                    tasks.push(tokio::spawn(proxy.serve(rx.clone())));
                 }
                 ListenerConfig::TLS(tls_cfg) => {
                     info!("Starting TLS ingress on port {}", *port);
                     let proxy = EnclaveProxy::bind_tls(*port, tls_cfg.clone())?;
-                    tasks.push(tokio::spawn(proxy.serve()));
+                    tasks.push(tokio::spawn(proxy.serve(rx.clone())));
                 }
             }
         }
 
-        Ok(Self { proxies: tasks })
+        Ok(Self {
+            proxies: tasks,
+            shutdown: tx,
+        })
     }
 
     pub async fn stop(self) {
-        for p in &self.proxies {
-            p.abort();
-        }
+        self.shutdown.send(()).ignore();
 
         for p in self.proxies {
-            _ = p.await;
+            p.await.ignore();
         }
     }
 }


### PR DESCRIPTION
Prior to this change, if the application within the enclave exited
shortly after sending a particularly slow (e.g. large) response, the
ingress proxy tasks would be aborted before the transfer could
complete, causing the response to be prematurely terminated. Instead
of aborting the tasks, send a shutdown signal and wait for their
completion.

This fixes https://github.com/edgebitio/enclaver/issues/167.