### PR TITLE
Allow the manifest to be read from stdin

### DIFF
--- a/enclaver/src/bin/enclaver/main.rs
+++ b/enclaver/src/bin/enclaver/main.rs
@@ -24,7 +24,7 @@ enum Commands {
     /// Package a Docker image into a self-executing Enclaver container image.
     Build {
         #[clap(long = "file", short = 'f', default_value = "enclaver.yaml")]
-        /// Path to the Enclaver manifest file to build from.
+        /// Path to the Enclaver manifest file, or - to read it from stdin.
         manifest_file: String,
 
         #[clap(long = "eif-only", hide = true)]


### PR DESCRIPTION
This makes it a bit easier to use in a pipeline of commands. Rather than having to use a temporary file, the manifest can just be piped in directly when the filename argument is '-'.