### PR TITLE
Split SBOM upload and generation

### DIFF
--- a/.github/edgebit/source-syft.yaml
+++ b/.github/edgebit/source-syft.yaml
@@ -1,5 +1,3 @@
-output: syft
-
 check-for-app-update: false
 
 catalogers:

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -13,19 +13,23 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Download Syft
-        id: syft
-        uses: anchore/sbom-action/download-syft@v0.14.2
-
       - name: Generate SBOM from source code
-        run: "${{ steps.syft.outputs.cmd }} --config .github/edgebit/source-syft.yaml --file /tmp/sbom.syft.json ."
-
-      - name: Upload SBOM to EdgeBit
-        uses: edgebitio/edgebit-build@v1
+        uses: eyakubovich/sbom-action@ey/add-config-input
         with:
-          edgebit-url: "https://edgebit.edgebit.io"
-          token: ${{ secrets.EDGEBIT_TOKEN }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          sbom-file: /tmp/sbom.syft.json
-          component: "enclaver"
-          tags: ${{ github.ref == 'refs/heads/main' && 'latest' || '' }}
+          artifact-name: sbom.spdx.json
+          upload-artifact: true
+          config: .github/edgebit/source-syft.yaml
+
+      - name: Save metadata to an artifact
+        run: |
+          cat > /tmp/metadata.json <<EOF
+            {
+              "pr-number": "${{ github.event.number }}",
+              "tags": "${{ github.ref == 'refs/heads/main' && 'latest' || '' }}"
+            }
+          EOF
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: metadata.json
+          path: /tmp/metadata.json

--- a/.github/workflows/upload-sbom.yaml
+++ b/.github/workflows/upload-sbom.yaml
@@ -1,0 +1,38 @@
+# based on https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+
+name: Upload SBOM to EdgeBit
+
+on:
+  workflow_run:
+    workflows: ["Generate an SBOM from source code"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Download metadata
+        id: metadata
+        uses: dawidd6/action-download-artifact@v2.28.0
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          name: metadata.json
+
+      - name: Download SBOM
+        id: sbom
+        uses: dawidd6/action-download-artifact@v2.28.0
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          name: sbom.spdx.json
+
+      - name: Upload SBOM to EdgeBit
+        uses: edgebitio/edgebit-build@v1
+        with:
+          edgebit-url: "https://edgebit.edgebit.io"
+          token: ${{ secrets.EDGEBIT_TOKEN }}
+          component: "enclaver"
+          sbom-file: ./sbom.spdx.json
+          args-file: ./metadata.json


### PR DESCRIPTION
Doing this as two different workflows allows the upload to make use of the origin's repo secret, while continuing to execute the generation without. This should enable scanning on pull requests from forks.