### PR TITLE
Generate SBOMs for tagged commits

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - 'main'
+    tags:
+      - '**'
 
 jobs:
   generate-sbom:


### PR DESCRIPTION
Releases are done from a branch which is not "main". This branch may also have a head commit that is not the release itself (i.e. a bump to the next development version) so run the workflow on the tag instead.