### PR TITLE
Launch container in privileged mode

### DIFF
--- a/enclaver/src/constants.rs
+++ b/enclaver/src/constants.rs
@@ -16,7 +16,7 @@ pub const HTTP_EGRESS_VSOCK_PORT: u32 = 17002;
 
 // Default TCP Port that the egress proxy listens on inside the enclave, if not
 // specified in the manifest.
-pub const HTTP_EGRESS_PROXY_PORT: u16 = 9000;
+pub const HTTP_EGRESS_PROXY_PORT: u16 = 10000;
 
 // The hostname to refer to the host side from inside the enclave.
 pub const OUTSIDE_HOST: &str = "host";

--- a/enclaver/src/run_container.rs
+++ b/enclaver/src/run_container.rs
@@ -81,6 +81,7 @@ impl RunWrapper {
                             cgroup_permissions: Some(String::from("rwm")),
                         }]),
                         port_bindings: Some(port_bindings),
+                        privileged: Some(true),
                         ..Default::default()
                     }),
                     exposed_ports: Some(exposed_ports),


### PR DESCRIPTION
- nitro-cli now binds to CID 3, requiring privileged mode
- The binding happens on port 9000 so use port 10000 for egress proxy