### PR TITLE
Cancel superseded GitHub workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,10 @@ name: CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: "sparse"
   RUSTFLAGS: "-Dwarnings"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,10 @@ on:
     tags:
       - v*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-release-binaries:
     strategy:

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -8,6 +8,10 @@ on:
     tags:
       - '**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   generate-sbom:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-sbom.yaml
+++ b/.github/workflows/upload-sbom.yaml
@@ -8,6 +8,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   upload:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This serves two purposes:

- cuts costs by canceling CI when pull requests are updated
- prevents issues when releasing after pull requests are merged

Elaborating on that second point, two pull requests are merged, so two release-image workflows are started as a result. The earlier one takes longer to run, however, and mutates the 'latest' tag last. This is a great example of the dangers of mutability.