### PR TITLE
Example: demo egress with https proxy

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -1,10 +1,27 @@
 const express = require('express');
+const axios = require('axios');
+const https_proxy_agent = require("https-proxy-agent");
+
 const app = express();
 const port = 8000;
 
-app.get('/', (req, res) => {
+app.get('/', (req, resOuter) => {
   console.log('Request received!');
-  res.send('Hello World!');
+  const agent = new https_proxy_agent.HttpsProxyAgent(process.env.HTTPS_PROXY);
+
+  axios.get('https://news.ycombinator.com', {
+    proxy: false,
+    httpsAgent: agent,
+  })
+    .then((resInner) => {
+      const status = resInner.status;
+      const contentType = resInner.headers['content-type'];
+      const data = resInner.data;
+
+      resOuter.status(status);
+      resOuter.set('content-type', contentType);
+      resOuter.send(data);
+    });
 })
 
 app.listen(port, () => {

--- a/example/enclaver.yaml
+++ b/example/enclaver.yaml
@@ -3,7 +3,12 @@ name: "example"
 target: "enclave:latest"
 sources:
   app: "app:latest"
+  supervisor: "odyn-dev:latest"
+  wrapper: "enclaver-wrapper-base:latest"
 defaults:
-  memory_mb: 1000
+  memory_mb: 1500
 ingress:
   - listen_port: 8000
+egress:
+  allow:
+    - news.ycombinator.com

--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,9 @@
   "private": false,
   "main": "app.js",
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "axios": "^1.8.3",
+    "https-proxy-agent": "7.0.6"
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
Modifies the example to perform an egress call
using axios + https-proxy-agent to demonstrate
the use of the http egress proxy.